### PR TITLE
Fixed xrfm config file in opt_space.

### DIFF
--- a/TALENT/configs/opt_space/xrfm.json
+++ b/TALENT/configs/opt_space/xrfm.json
@@ -3,31 +3,23 @@
         "model": {
             "bandwidth": [
                 "loguniform", 
-                [
-                    1, 
-                    200
-                ]
+                1, 
+                200
             ],
             "reg": [
                 "loguniform", 
-                [
-                    1e-6, 
-                    1e0
-                ]
+                1e-6, 
+                1e0
             ],
             "exponent": [
                 "uniform", 
-                [
-                    0.7, 
-                    1.4
-                ]
+                0.7, 
+                1.4
             ],
             "p_interp": [
                 "uniform", 
-                [
-                    0.0, 
-                    0.8
-                ]
+                0.0, 
+                0.8
             ],
             "kernel_type": [
                 "categorical", 


### PR DESCRIPTION
I noticed the format was off for the loguniform/uniform param spaces in opt_space/xrfm.json. I fixed these and tested locally with default and HPO -> only need to merge that file.