### PR TITLE
Add probability support for SVM, NCM, NaiveBayes, Dummy methods

### DIFF
--- a/TALENT/model/classical_methods/dummy.py
+++ b/TALENT/model/classical_methods/dummy.py
@@ -1,8 +1,8 @@
 from TALENT.model.classical_methods.base import classical_methods
-from copy import deepcopy
 import os.path as ops
 import pickle
 import time
+from sklearn.metrics import accuracy_score, mean_squared_error
 
 class DummyMethod(classical_methods):
     def __init__(self, args, is_regression):
@@ -11,50 +11,41 @@ class DummyMethod(classical_methods):
 
     def construct_model(self, model_config = None):
         if model_config is None:
-            model_config = self.args.config['model']
+            model_config = self.args.config.get('model', {})
         from sklearn.dummy import DummyClassifier, DummyRegressor
         if self.is_regression:
-            self.model = DummyRegressor(strategy='mean')
+            strategy = model_config.get('strategy', 'mean')
+            self.model = DummyRegressor(strategy=strategy)
         else:
-            self.model = DummyClassifier()
-
+            strategy = model_config.get('strategy', 'prior')
+            self.model = DummyClassifier(strategy=strategy, random_state=self.args.seed)
 
     def fit(self, data, info, train=True, config=None):
         super().fit(data, info, train, config)
-        # if not train, skip the training process. such as load the checkpoint and directly predict the results
         if not train:
             return
         tic = time.time()
         self.model.fit(self.N['train'], self.y['train'])
-        self.trlog['best_res'] = self.model.score(self.N['val'], self.y['val'])
+        if not self.is_regression:
+            y_val_pred = self.model.predict(self.N['val'])
+            self.trlog['best_res'] = accuracy_score(self.y['val'], y_val_pred)
+        else:
+            y_val_pred = self.model.predict(self.N['val'])
+            self.trlog['best_res'] = mean_squared_error(self.y['val'], y_val_pred, squared=False)*self.y_info['std']
         time_cost = time.time() - tic
-        with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
+        with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)
         return time_cost
 
-    def predict(self,data, info, model_name):
+    def predict(self, data, info, model_name):
         N, C, y = data
-        with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'rb') as f:
+        with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'rb') as f:
             self.model = pickle.load(f)
         self.data_format(False, N, C, y)
         test_label = self.y_test
-        test_logit = self.model.predict(self.N_test)
+        if self.is_regression:
+            test_logit = self.model.predict(self.N_test)
+        else:
+            test_logit = self.model.predict_proba(self.N_test)
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
         return vres, metric_name, test_logit
-    
-    def metric(self, predictions, labels, y_info):
-        from sklearn import metrics as skm
-        if self.is_regression:
-            mae = skm.mean_absolute_error(labels, predictions)
-            rmse = skm.mean_squared_error(labels, predictions) ** 0.5
-            r2 = skm.r2_score(labels, predictions)
-            if y_info['policy'] == 'mean_std':
-                mae *= y_info['std']
-                rmse *= y_info['std']
-            return (mae,r2,rmse), ("MAE", "R2", "RMSE")
-        else:
-            accuracy = skm.accuracy_score(labels, predictions)
-            avg_precision = skm.precision_score(labels, predictions, average='macro')
-            avg_recall = skm.recall_score(labels, predictions, average='macro')
-            f1_score = skm.f1_score(labels, predictions, average='binary' if self.is_binclass else 'macro')
-            return (accuracy, avg_precision, avg_recall, f1_score), ("Accuracy", "Avg_Precision", "Avg_Recall", "F1")

--- a/TALENT/model/classical_methods/naivebayes.py
+++ b/TALENT/model/classical_methods/naivebayes.py
@@ -5,8 +5,17 @@ import pickle
 class NaiveBayesMethod(NCMMethod):
     def __init__(self, args, is_regression):
         super().__init__(args, is_regression)
-        
+
     def construct_model(self, model_config = None):
         from sklearn.naive_bayes import GaussianNB
         self.model = GaussianNB()
-    
+
+    def predict(self, data, info, model_name):
+        N, C, y = data
+        with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'rb') as f:
+            self.model = pickle.load(f)
+        self.data_format(False, N, C, y)
+        test_label = self.y_test
+        test_logit = self.model.predict_proba(self.N_test)
+        vres, metric_name = self.metric(test_logit, test_label, self.y_info)
+        return vres, metric_name, test_logit

--- a/TALENT/model/classical_methods/ncm.py
+++ b/TALENT/model/classical_methods/ncm.py
@@ -2,6 +2,8 @@ from TALENT.model.classical_methods.base import classical_methods
 import os.path as ops
 import pickle
 import time
+import numpy as np
+from sklearn.metrics.pairwise import euclidean_distances
 
 class NCMMethod(classical_methods):
     def __init__(self, args, is_regression):
@@ -13,34 +15,32 @@ class NCMMethod(classical_methods):
     def construct_model(self, model_config = None):
         from sklearn.neighbors import NearestCentroid
         self.model = NearestCentroid()
-    
+
     def fit(self, data, info, train=True, config=None):
         super().fit(data, info, train, config)
-        # if not train, skip the training process. such as load the checkpoint and directly predict the results
         if not train:
             return
         tic = time.time()
         self.model.fit(self.N['train'], self.y['train'])
         self.trlog['best_res'] = self.model.score(self.N['val'], self.y['val'])
         time_cost = time.time() - tic
-        with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
+        with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)
         return time_cost
-    
+
+    def _predict_proba(self, X):
+        distances = euclidean_distances(X, self.model.centroids_)
+        neg_distances = -distances
+        exp_neg_dist = np.exp(neg_distances - np.max(neg_distances, axis=1, keepdims=True))
+        probabilities = exp_neg_dist / np.sum(exp_neg_dist, axis=1, keepdims=True)
+        return probabilities
+
     def predict(self, data, info, model_name):
         N, C, y = data
-        with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'rb') as f:
+        with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'rb') as f:
             self.model = pickle.load(f)
         self.data_format(False, N, C, y)
         test_label = self.y_test
-        test_logit = self.model.predict(self.N_test)
+        test_logit = self._predict_proba(self.N_test)
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
         return vres, metric_name, test_logit
-    
-    def metric(self, predictions, labels, y_info):
-        from sklearn import metrics as skm
-        accuracy = skm.accuracy_score(labels, predictions)
-        avg_precision = skm.precision_score(labels, predictions,average='macro')
-        avg_recall = skm.recall_score(labels, predictions, average='macro')
-        f1_score = skm.f1_score(labels, predictions, average= 'binary' if self.is_binclass else 'macro')
-        return (accuracy, avg_precision, avg_recall, f1_score), ("Accuracy", "Avg_Precision", "Avg_Recall", "F1")

--- a/TALENT/model/classical_methods/svm.py
+++ b/TALENT/model/classical_methods/svm.py
@@ -17,12 +17,14 @@ class SvmMethod(classical_methods):
         if self.is_regression:
             self.model = LinearSVR(**model_config)
         else:
-            self.model = LinearSVC(**model_config,random_state=self.args.seed)
-
+            from sklearn.calibration import CalibratedClassifierCV
+            base_svc = LinearSVC(**model_config, random_state=self.args.seed)
+            self.model = CalibratedClassifierCV(
+                estimator=base_svc, method='sigmoid', cv=3, n_jobs=1
+            )
 
     def fit(self, data, info, train=True, config=None):
         super().fit(data, info, train, config)
-        # if not train, skip the training process. such as load the checkpoint and directly predict the results
         if not train:
             return
         tic = time.time()
@@ -34,33 +36,19 @@ class SvmMethod(classical_methods):
             y_val_pred = self.model.predict(self.N['val'])
             self.trlog['best_res'] = mean_squared_error(self.y['val'], y_val_pred, squared=False)*self.y_info['std']
         time_cost = time.time() - tic
-        with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
+        with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)
         return time_cost
 
     def predict(self, data, info, model_name):
         N, C, y = data
-        with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'rb') as f:
+        with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'rb') as f:
             self.model = pickle.load(f)
         self.data_format(False, N, C, y)
         test_label = self.y_test
-        test_logit = self.model.predict(self.N_test)
+        if self.is_regression:
+            test_logit = self.model.predict(self.N_test)
+        else:
+            test_logit = self.model.predict_proba(self.N_test)
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
         return vres, metric_name, test_logit
-    
-    def metric(self, predictions, labels, y_info):
-        from sklearn import metrics as skm
-        if self.is_regression:
-            mae = skm.mean_absolute_error(labels, predictions)
-            rmse = skm.mean_squared_error(labels, predictions) ** 0.5
-            r2 = skm.r2_score(labels, predictions)
-            if y_info['policy'] == 'mean_std':
-                mae *= y_info['std']
-                rmse *= y_info['std']
-            return (mae,r2,rmse), ("MAE", "R2", "RMSE")
-        else:
-            accuracy = skm.accuracy_score(labels, predictions)
-            avg_precision = skm.precision_score(labels, predictions, average='macro')
-            avg_recall = skm.recall_score(labels, predictions, average='macro')
-            f1_score = skm.f1_score(labels, predictions, average='binary' if self.is_binclass else 'macro')
-            return (accuracy, avg_precision, avg_recall, f1_score), ("Accuracy", "Avg_Precision", "Avg_Recall", "F1")


### PR DESCRIPTION
## Summary

This PR adds probability output support (`predict_proba`) to four classical methods that previously only returned class labels. This enables proper AUC calculation using the base class `metric()` function.

## Methods Fixed

| Method | Solution |
|--------|----------|
| **SVM** | Wrap `LinearSVC` with `CalibratedClassifierCV` (Platt scaling) |
| **NCM** | Compute `softmax(-distances)` to class centroids |
| **NaiveBayes** | Use `GaussianNB`'s native `predict_proba()` |
| **Dummy** | Use `strategy='prior'` which supports `predict_proba()` |

## Changes

- `svm.py`: Classification now uses `CalibratedClassifierCV(LinearSVC)` instead of raw `LinearSVC`
- `ncm.py`: Added `_predict_proba()` method using softmax over negative centroid distances
- `naivebayes.py`: Changed `predict()` to use `predict_proba()` instead of `predict()`
- `dummy.py`: Uses `strategy='prior'` (default) which supports probability estimates

## Why This Matters

The base class `metric()` in `classical_methods/base.py` already computes AUC when given probability arrays. These methods were missing AUC because they returned class labels instead of probabilities. Now all four methods work with the full metric suite including AUC.

## Testing

Tested on credit risk classification datasets. All methods now produce valid probability outputs and AUC is computed correctly.