### PR TITLE
Incorrect MSE Loss Calculation Due to Tensor Broadcasting

### DIFF
--- a/TALENT/model/lib/data.py
+++ b/TALENT/model/lib/data.py
@@ -452,6 +452,15 @@ def data_label_process(y_data, is_regression, info = None, encoder = None):
             info = {'policy': 'none', 'classes': np.unique(y['train']), 'n_classes': len(np.unique(y['train']))}
         return y, info, encoder
 
+
+def mse_safe_broadcast(input, target) -> torch.Tensor:
+    assert target.dim() in [1, 2], f"Unexpected target.shape = {target.shape}"
+    if target.dim() == 2 and target.size(-1) == 1:
+        target = target.squeeze(-1)
+    assert input.shape == target.shape, f"{input.shape} != {target.shape}"
+    return torch.nn.functional.mse_loss(input=input, target=target)
+
+
 def data_loader_process(is_regression, X, Y, y_info, device, batch_size, is_train,is_float = False):
     """
     Process the data loader.
@@ -486,7 +495,7 @@ def data_loader_process(is_regression, X, Y, y_info, device, batch_size, is_trai
         Y = {k: v.long() for k, v in Y.items()}
     
     loss_fn = (
-        F.mse_loss
+        mse_safe_broadcast
         if is_regression
         else F.cross_entropy
     )


### PR DESCRIPTION
## Problem Summary
A critical bug in MSE loss calculations occurs with incompatible tensor shapes: `(n, 1)` vs `(n,)`. PyTorch's automatic broadcasting silently converts to `(n, n)` instead of element-wise comparison.

## Issue Details
- **When**: `F.mse_loss(y_true, y_pred)` called with `y_true.shape = (n, 1)` and `y_pred.shape = (n,)`
- **What happens**: Silent broadcast to `(n, n)` instead of element-wise comparison
- **Result**: Model minimizes differences between all pairs `(y_true[i], y_pred[j])` instead of corresponding pairs `(y_true[i], y_pred[i])`
- **Effect**: Incorrect training, failure to converge, silent performance degradation

## Solution Implemented
Added `mse_safe_broadcast()` function with comprehensive tensor shape validation

### Key Features
1. **Automatic Shape Handling**: Automatically reshapes `(n, 1)` → `(n,)` tensors when necessary
2. **Explicit Validation**: Assertions to catch shape mismatches early in training pipeline
3. **Backward Compatibility**: Existing code works without modification
4. **Debug-Friendly**: Clear error messages with shape information for rapid debugging


Fixes issue #64