### PR TITLE
real python API and the unified method registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,11 @@ To add new methods to the codebase:
 For methods similar to MLP (only model design needed):
 1. Add model class in `model/models/`
 2. Inherit from `model/methods/base.py` and override `construct_model()`
-3. Add method name in `get_method()` function in `model/utils.py`
+3. Register the method in the unified registry at `model/method_registry.py`
+   by appending a `MethodSpec(...)` entry (declaring `cat_policy`,
+   `normalization`, `output_type`, `supports_hpo`, etc.). The CLI argparse
+   `choices` lists and `get_method()` are both derived from this registry,
+   so no other dispatcher edits are needed.
 4. Add parameter settings in:
    - `configs/default/[MODEL_NAME].json`
    - `configs/opt_space/[MODEL_NAME].json`

--- a/TALENT/__init__.py
+++ b/TALENT/__init__.py
@@ -1,4 +1,74 @@
+"""TALENT — A Tabular Analytics and Learning Toolbox.
+
+Two ways to use TALENT:
+
+1. **CLI scripts** (original, unchanged):
+
+   .. code-block:: bash
+
+       python train_model_deep.py --model_type tabpfn_v3
+       python train_model_classical.py --model_type catboost
+
+2. **Python API** (added 2026, library mode):
+
+   .. code-block:: python
+
+       import TALENT
+       from TALENT.model.lib.data import get_dataset
+
+       train_val, test, info = get_dataset("housing", "./data")
+       result = TALENT.run("tabpfn_v3", train_val, test, info)
+       print(result.metrics, result.metric_names)
+
+       # Introspect:
+       spec = TALENT.get_method_spec("tabpfn_v3")
+       print(spec.cat_policy, spec.supports_hpo, spec.train_row_limit)
+
+       # Enumerate available methods:
+       for s in TALENT.list_methods(architecture=TALENT.Architecture.DEEP):
+           print(s.name)
+
+Both surfaces share a single :class:`MethodSpec` registry, so adding a new
+method requires only a registry entry (no changes to CLI or API code).
 """
-This is the TALENT package.
-"""
-__version__ = "0.0.1"
+
+__version__ = "0.1.0"
+
+# Lazy import surface: importing TALENT does NOT pull in torch.
+# Each name is resolved on first access via `__getattr__`.
+
+_LAZY_API = {
+    "run": "TALENT.api",
+    "run_from_dataset": "TALENT.api",
+    "build_args": "TALENT.api",
+    "RunResult": "TALENT.api",
+}
+
+_LAZY_REGISTRY = {
+    "MethodSpec": "TALENT.model.method_registry",
+    "METHOD_REGISTRY": "TALENT.model.method_registry",
+    "Architecture": "TALENT.model.method_registry",
+    "Hardware": "TALENT.model.method_registry",
+    "OutputType": "TALENT.model.method_registry",
+    "get_method_spec": "TALENT.model.method_registry",
+    "get_method_class": "TALENT.model.method_registry",
+    "list_methods": "TALENT.model.method_registry",
+    "deep_method_names": "TALENT.model.method_registry",
+    "classical_method_names": "TALENT.model.method_registry",
+    "all_method_names": "TALENT.model.method_registry",
+}
+
+
+def __getattr__(name):
+    """Lazy attribute resolution. Loads the right submodule on first access."""
+    import importlib
+    target = _LAZY_REGISTRY.get(name) or _LAZY_API.get(name)
+    if target is None:
+        raise AttributeError(f"module 'TALENT' has no attribute {name!r}")
+    mod = importlib.import_module(target)
+    obj = getattr(mod, name)
+    globals()[name] = obj  # cache so subsequent attribute access is fast
+    return obj
+
+
+__all__ = ["__version__"] + sorted(set(_LAZY_REGISTRY) | set(_LAZY_API))

--- a/TALENT/api.py
+++ b/TALENT/api.py
@@ -1,0 +1,564 @@
+"""Public Python API for TALENT.
+
+TALENT was originally designed as a CLI tool with `train_model_deep.py` /
+`train_model_classical.py` driving everything through argparse on
+`sys.argv`. This module exposes the same functionality as a regular Python
+API, so downstream code (notebooks, benchmarking pipelines, scikit-learn
+wrappers) can call into TALENT without manipulating argv.
+
+Quick examples
+--------------
+
+>>> import TALENT
+>>> from TALENT.model.lib.data import get_dataset
+>>>
+>>> train_val, test, info = get_dataset("housing", "./data")
+>>> result = TALENT.run("catboost", train_val, test, info)
+>>> result.metrics, result.metric_names
+>>> result.predictions  # in original target scale for regression
+
+>>> # Hyperparameter tuning:
+>>> result = TALENT.run("mlp", train_val, test, info, tune=True, n_trials=50)
+
+>>> # Multiple seeds, aggregated:
+>>> result = TALENT.run("tabpfn_v3", train_val, test, info, seed_num=3)
+>>> result.metrics_mean, result.metrics_std
+
+>>> # Introspect a method:
+>>> spec = TALENT.get_method_spec("tabpfn_v2")
+>>> spec.cat_policy, spec.normalization, spec.supports_hpo
+
+>>> # List methods by capability:
+>>> from TALENT.model.method_registry import Architecture
+>>> [s.name for s in TALENT.list_methods(architecture=Architecture.DEEP)]
+
+The CLI scripts continue to work unchanged. Both surfaces go through the
+same `MethodSpec` registry, so adding a new method requires no changes to
+either layer beyond a registry entry.
+"""
+
+from __future__ import annotations
+
+import os
+import os.path as osp
+import json
+import time
+import tempfile
+import warnings
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import importlib.resources as pkg_resources
+import numpy as np
+
+from TALENT.model.method_registry import (
+    METHOD_REGISTRY,
+    MethodSpec,
+    Architecture,
+    Hardware,
+    OutputType,
+    get_method_spec,
+    get_method_class,
+    list_methods,
+    deep_method_names,
+    classical_method_names,
+    all_method_names,
+)
+
+
+# ----------------------------------------------------------------------------
+#  Result dataclass
+# ----------------------------------------------------------------------------
+
+@dataclass
+class RunResult:
+    """Output of a single :func:`run` call.
+
+    For single-seed runs, the `*_mean` / `*_std` fields are equal to the
+    single value and 0.0 respectively, so the API shape is stable.
+    """
+    predictions: np.ndarray
+    loss: float
+    metrics: Tuple[float, ...]
+    metric_names: Tuple[str, ...]
+    fit_time: float
+    predict_time: float
+
+    # Multi-seed aggregates (filled when seed_num > 1)
+    loss_mean: float = 0.0
+    loss_std: float = 0.0
+    metrics_mean: Tuple[float, ...] = field(default_factory=tuple)
+    metrics_std: Tuple[float, ...] = field(default_factory=tuple)
+    per_seed: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Bookkeeping
+    method_type: str = ""
+    config: Dict[str, Any] = field(default_factory=dict)
+    save_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-safe summary (predictions excluded)."""
+        d = {
+            "method_type": self.method_type,
+            "loss": float(self.loss),
+            "loss_mean": float(self.loss_mean),
+            "loss_std": float(self.loss_std),
+            "metrics": dict(zip(self.metric_names, [float(x) for x in self.metrics])),
+            "metrics_mean": dict(zip(self.metric_names, [float(x) for x in self.metrics_mean])) if self.metrics_mean else {},
+            "metrics_std": dict(zip(self.metric_names, [float(x) for x in self.metrics_std])) if self.metrics_std else {},
+            "fit_time": float(self.fit_time),
+            "predict_time": float(self.predict_time),
+            "save_path": self.save_path,
+        }
+        return d
+
+
+# ----------------------------------------------------------------------------
+#  Args builder (replaces argparse + sys.argv for programmatic use)
+# ----------------------------------------------------------------------------
+
+# Default values that mirror configs/deep_configs.json and classical_configs.json
+# but are baked in so the API works even when no JSON file is found.
+_DEEP_DEFAULTS = {
+    "dataset": "",
+    "max_epoch": 200,
+    "batch_size": 1024,
+    "normalization": "standard",
+    "num_nan_policy": "mean",
+    "cat_nan_policy": "new",
+    "cat_policy": "indices",
+    "num_policy": "none",
+    "n_bins": 2,
+    "cat_min_frequency": 0.0,
+    "n_trials": 50,
+    "seed_num": 1,
+    "workers": 0,
+    "gpu": "0",
+    "tune": False,
+    "retune": False,
+    "evaluate_option": "best-val",
+    "dataset_path": "./data",
+    "model_path": "./checkpoints",
+    "use_float": False,
+}
+
+_CLASSICAL_DEFAULTS = {
+    "dataset": "",
+    "normalization": "standard",
+    "num_nan_policy": "mean",
+    "cat_nan_policy": "new",
+    "cat_policy": "ohe",
+    "num_policy": "none",
+    "n_bins": 2,
+    "cat_min_frequency": 0.0,
+    "n_trials": 50,
+    "seed_num": 1,
+    "gpu": "0",
+    "tune": False,
+    "retune": False,
+    "dataset_path": "./data",
+    "model_path": "./checkpoints",
+    "evaluate_option": "best-val",
+    "use_float": False,
+}
+
+
+def _try_load_packaged_defaults(filename: str) -> Dict[str, Any]:
+    """Best-effort: load packaged `configs/<filename>` defaults if present."""
+    try:
+        import TALENT
+        with pkg_resources.files(TALENT).joinpath(f"configs/{filename}").open("r") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _try_load_method_config(model_type: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Return (default_config, opt_space_config) for `model_type` from
+    packaged JSONs. Returns empty dicts if not available.
+    """
+    default_cfg: Dict[str, Any] = {}
+    opt_cfg: Dict[str, Any] = {}
+    try:
+        import TALENT
+        with pkg_resources.files(TALENT).joinpath(f"configs/default/{model_type}.json").open("r") as f:
+            default_cfg = json.load(f)
+    except Exception:
+        pass
+    try:
+        import TALENT
+        with pkg_resources.files(TALENT).joinpath(f"configs/opt_space/{model_type}.json").open("r") as f:
+            opt_cfg = json.load(f)
+    except Exception:
+        pass
+    return default_cfg, opt_cfg
+
+
+def build_args(
+    model_type: str,
+    *,
+    save_path: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+    apply_spec_constraints: bool = True,
+    **overrides,
+) -> SimpleNamespace:
+    """Build an `args` namespace equivalent to what argparse would produce.
+
+    Parameters
+    ----------
+    model_type : str
+        Name from the method registry (e.g. ``"tabpfn_v2"``, ``"catboost"``).
+    save_path : str, optional
+        Working directory for checkpoints / tuned configs. If None, a fresh
+        temp directory is created.
+    config : dict, optional
+        Method config (``{"model": {...}, "training": {...}, "general": {...}}``).
+        If None, the packaged default config is loaded.
+    apply_spec_constraints : bool, default True
+        If True, override `cat_policy`, `normalization`, and `num_policy`
+        with the values required by the method spec (so the asserts in
+        each method's `__init__` cannot fail).
+    **overrides
+        Anything else (``seed``, ``batch_size``, ``max_epoch``, ``tune``,
+        ``n_trials``, ...). These override the defaults and any packaged
+        config values.
+
+    Returns
+    -------
+    SimpleNamespace
+        Drop-in replacement for `argparse.Namespace`, accepted by every
+        Method class.
+    """
+    spec = get_method_spec(model_type)
+
+    # Start from architecture-appropriate defaults
+    base = (_DEEP_DEFAULTS if spec.architecture == Architecture.DEEP
+            else _CLASSICAL_DEFAULTS).copy()
+
+    # Layer in packaged config defaults if they exist
+    packaged = _try_load_packaged_defaults(
+        "deep_configs.json" if spec.architecture == Architecture.DEEP
+        else "classical_configs.json"
+    )
+    for k, v in packaged.items():
+        if k in base:  # only override known fields, ignore extras
+            base[k] = v
+
+    # User overrides win
+    base["model_type"] = model_type
+    for k, v in overrides.items():
+        base[k] = v
+
+    # Enforce method-spec preprocessing constraints
+    if apply_spec_constraints:
+        if spec.cat_policy is not None and base.get("cat_policy") not in spec.cat_policy:
+            base["cat_policy"] = spec.cat_policy[0]
+        if spec.normalization is not None:
+            base["normalization"] = spec.normalization
+        if spec.num_policy is not None:
+            base["num_policy"] = spec.num_policy
+
+    # Resolve save_path
+    if save_path is None:
+        save_path = tempfile.mkdtemp(prefix=f"talent-{model_type}-")
+    base["save_path"] = save_path
+    os.makedirs(save_path, exist_ok=True)
+
+    # Default seed
+    base.setdefault("seed", 0)
+
+    # Method config: packaged default, then user override
+    if config is None:
+        default_cfg, _ = _try_load_method_config(model_type)
+        # default_cfg is wrapped one level: { model_type: { model/training/general } }
+        if model_type in default_cfg:
+            config = default_cfg[model_type]
+        else:
+            # Minimal fallback so methods that read training/lr etc. still work
+            config = {"model": {}, "training": {}, "general": {}}
+    base["config"] = config
+
+    # n_bins propagation matches the CLI behaviour
+    try:
+        if spec.architecture == Architecture.DEEP:
+            base["config"].setdefault("training", {})["n_bins"] = base["n_bins"]
+        else:
+            base["config"].setdefault("fit", {})["n_bins"] = base["n_bins"]
+    except Exception:
+        pass
+
+    args = SimpleNamespace(**base)
+
+    # Validate so we fail with a readable message rather than an obscure assert.
+    if apply_spec_constraints:
+        spec.validate_args(args)
+
+    return args
+
+
+# ----------------------------------------------------------------------------
+#  Core run function
+# ----------------------------------------------------------------------------
+
+def _aggregate_metrics(per_seed: List[Dict[str, Any]], metric_names: Tuple[str, ...]):
+    losses = np.array([s["loss"] for s in per_seed], dtype=float)
+    metrics_matrix = np.array([list(s["metrics"]) for s in per_seed], dtype=float)
+    return (
+        float(losses.mean()),
+        float(losses.std()),
+        tuple(metrics_matrix.mean(axis=0).tolist()),
+        tuple(metrics_matrix.std(axis=0).tolist()),
+    )
+
+
+def run(
+    model_type: str,
+    train_val_data: Tuple[Any, Any, Any],
+    test_data: Tuple[Any, Any, Any],
+    info: Dict[str, Any],
+    *,
+    config: Optional[Dict[str, Any]] = None,
+    args: Optional[SimpleNamespace] = None,
+    seed: int = 0,
+    seed_num: int = 1,
+    tune: bool = False,
+    n_trials: int = 50,
+    save_path: Optional[str] = None,
+    return_method: bool = False,
+    verbose: bool = False,
+    **arg_overrides,
+) -> RunResult:
+    """Fit a TALENT method on ``train_val_data`` and predict on ``test_data``.
+
+    Parameters
+    ----------
+    model_type : str
+        Name from the registry (``TALENT.list_methods()`` to enumerate).
+    train_val_data : (N, C, y)
+        Tuple of dicts keyed by 'train' / 'val', as returned by
+        :func:`TALENT.model.lib.data.get_dataset`. Each element may be
+        ``None`` if the dataset has no numerical / categorical features.
+    test_data : (N, C, y)
+        Same shape as `train_val_data` but keyed by ``'test'``.
+    info : dict
+        Dataset info dict (`task_type`, `n_num_features`, `n_cat_features`).
+    config : dict, optional
+        Method-specific config. If None, the packaged default is used.
+    args : SimpleNamespace, optional
+        Pre-built args. If supplied, all of the per-call kwargs below are
+        ignored (you can also pass `seed` to override `args.seed`). Pass
+        the output of :func:`build_args` here when you want fine control.
+    seed : int, default 0
+        Random seed (used when seed_num == 1).
+    seed_num : int, default 1
+        Run multiple seeds (0..seed_num-1) and aggregate metrics. The
+        returned `predictions` are from the *last* seed; per-seed details
+        are in `result.per_seed`.
+    tune : bool, default False
+        If True and the method supports HPO, run Optuna tuning first.
+    n_trials : int, default 50
+        Optuna trial budget (when tune=True).
+    save_path : str, optional
+        Where to save checkpoints / tuned configs. Auto-generated if None.
+    return_method : bool, default False
+        If True, attach the fitted method object to ``result.method``.
+        Adds RAM cost, so off by default.
+    verbose : bool, default False
+        Forwarded to the method when supported.
+    **arg_overrides
+        Passed through to :func:`build_args`.
+
+    Returns
+    -------
+    RunResult
+    """
+    spec = get_method_spec(model_type)
+
+    if tune and not spec.supports_hpo:
+        raise ValueError(
+            f"Method {model_type!r} does not support HPO. "
+            f"Set tune=False or pick a tunable method."
+        )
+
+    # Build args if not provided
+    if args is None:
+        args = build_args(
+            model_type,
+            save_path=save_path,
+            config=config,
+            seed=seed,
+            seed_num=seed_num,
+            tune=tune,
+            n_trials=n_trials,
+            **arg_overrides,
+        )
+    else:
+        # Honour late overrides
+        if seed is not None:
+            args.seed = seed
+        if save_path is not None:
+            args.save_path = save_path
+            os.makedirs(save_path, exist_ok=True)
+
+    # Lazy imports — we don't want to drag torch in just for `list_methods()`.
+    import torch
+    from TALENT.model.utils import (
+        set_seeds, tune_hyper_parameters,
+    )
+
+    # Resolve device
+    if not hasattr(args, "device"):
+        args.device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+
+    # Detect regression
+    is_regression = info.get('task_type') == 'regression'
+    if is_regression and not spec.supports_regression:
+        raise ValueError(
+            f"Method {model_type!r} does not support regression. "
+            f"Use a method where supports_regression is True."
+        )
+    if (not is_regression) and not spec.supports_classification:
+        raise ValueError(
+            f"Method {model_type!r} does not support classification. "
+            f"Use a method where supports_classification is True."
+        )
+
+    method_cls = spec.get_class()
+
+    # Optional HPO. The current `tune_hyper_parameters` mutates args.config.
+    if tune and spec.supports_hpo:
+        # Load opt_space — required by tune_hyper_parameters
+        _, opt_space = _try_load_method_config(model_type)
+        if not opt_space:
+            raise FileNotFoundError(
+                f"opt_space config for {model_type!r} not found in packaged configs."
+            )
+        args = tune_hyper_parameters(args, opt_space, train_val_data, info)
+
+    per_seed: List[Dict[str, Any]] = []
+    last_predictions: Optional[np.ndarray] = None
+    last_metric_names: Tuple[str, ...] = ()
+    fit_times: List[float] = []
+    predict_times: List[float] = []
+    method = None
+
+    for s in range(seed_num):
+        args.seed = s if seed_num > 1 else seed
+        set_seeds(args.seed)
+        if verbose:
+            print(f"[TALENT.api.run] seed={args.seed} method={model_type}")
+
+        method = method_cls(args, is_regression)
+        fit_ret = method.fit(train_val_data, info)
+        # Some methods return time_cost from fit; some set self.fit_time. We use
+        # self.fit_time when available (set in our bugfix sweep across methods).
+        fit_time = getattr(method, "fit_time", None)
+        if fit_time is None and isinstance(fit_ret, (int, float)):
+            fit_time = float(fit_ret)
+        elif fit_time is None:
+            fit_time = 0.0
+
+        ret = method.predict(test_data, info, model_name=args.evaluate_option)
+        # Deep methods return (vl, vres, metric_names, predictions);
+        # classical methods return (vres, metric_names, predictions).
+        if len(ret) == 4:
+            vl, vres, metric_names, preds = ret
+        elif len(ret) == 3:
+            vres, metric_names, preds = ret
+            vl = float("nan")
+        else:
+            raise RuntimeError(
+                f"Unexpected predict() return arity {len(ret)} for {model_type!r}"
+            )
+
+        # Coerce to numpy if needed
+        if hasattr(preds, "detach"):
+            preds = preds.detach().cpu().numpy()
+        preds = np.asarray(preds)
+
+        predict_time = float(getattr(method, "predict_time", 0.0))
+        fit_times.append(float(fit_time))
+        predict_times.append(predict_time)
+
+        per_seed.append({
+            "seed": args.seed,
+            "loss": float(vl) if vl == vl else float("nan"),  # NaN-safe
+            "metrics": tuple(float(x) for x in vres),
+            "metric_names": tuple(metric_names),
+            "fit_time": float(fit_time),
+            "predict_time": predict_time,
+            "predictions": preds,
+        })
+        last_predictions = preds
+        last_metric_names = tuple(metric_names)
+
+    # Aggregate
+    if seed_num > 1:
+        loss_mean, loss_std, m_mean, m_std = _aggregate_metrics(per_seed, last_metric_names)
+    else:
+        loss_mean = per_seed[0]["loss"]
+        loss_std = 0.0
+        m_mean = per_seed[0]["metrics"]
+        m_std = tuple(0.0 for _ in last_metric_names)
+
+    result = RunResult(
+        predictions=last_predictions,
+        loss=per_seed[-1]["loss"],
+        metrics=per_seed[-1]["metrics"],
+        metric_names=last_metric_names,
+        fit_time=float(np.mean(fit_times)) if fit_times else 0.0,
+        predict_time=float(np.mean(predict_times)) if predict_times else 0.0,
+        loss_mean=loss_mean,
+        loss_std=loss_std,
+        metrics_mean=m_mean,
+        metrics_std=m_std,
+        per_seed=per_seed,
+        method_type=model_type,
+        config=getattr(args, "config", {}) or {},
+        save_path=getattr(args, "save_path", None),
+    )
+    if return_method:
+        result.method = method  # type: ignore[attr-defined]
+    return result
+
+
+# ----------------------------------------------------------------------------
+#  Convenience entry points
+# ----------------------------------------------------------------------------
+
+def run_from_dataset(
+    model_type: str,
+    dataset: str,
+    dataset_path: str = "./data",
+    **kwargs,
+) -> RunResult:
+    """Load a dataset from disk via :func:`TALENT.model.lib.data.get_dataset`
+    and run a method on it. Thin wrapper for the common case.
+    """
+    from TALENT.model.lib.data import get_dataset
+    train_val_data, test_data, info = get_dataset(dataset, dataset_path)
+    return run(model_type, train_val_data, test_data, info,
+               dataset=dataset, dataset_path=dataset_path, **kwargs)
+
+
+__all__ = [
+    # Result type
+    "RunResult",
+    # Args / runner
+    "build_args",
+    "run",
+    "run_from_dataset",
+    # Registry surface (re-exported for convenience)
+    "MethodSpec",
+    "METHOD_REGISTRY",
+    "Architecture",
+    "Hardware",
+    "OutputType",
+    "get_method_spec",
+    "get_method_class",
+    "list_methods",
+    "deep_method_names",
+    "classical_method_names",
+    "all_method_names",
+]

--- a/TALENT/model/method_registry.py
+++ b/TALENT/model/method_registry.py
@@ -1,0 +1,395 @@
+"""Unified method registry for TALENT.
+
+Single source of truth for every model's metadata: architecture, hardware,
+required preprocessing policy, output type, HPO support, etc. Replaces the
+giant if/elif chain in `utils.get_method()` and the hand-written argparse
+`choices` lists.
+
+The registry is also the basis of the public Python API in `TALENT.api`,
+where downstream code can introspect properties of a method without having
+to read its source.
+
+Each entry is derived from the actual `__init__` asserts in the method
+file (e.g. `assert(args.cat_policy == 'indices')`) plus inspection of the
+`predict()` return shape, so this is not aspirational — it documents what
+TALENT already requires today.
+
+Schema:
+    name            : str  -- canonical model_type string used by the CLI
+    module          : str  -- importable module path (lazy-loaded on use)
+    class_name      : str  -- class name inside that module
+    architecture    : Architecture.DEEP | Architecture.CLASSICAL
+    hardware        : Hardware.GPU | Hardware.CPU
+    output_type     : OutputType.LOGITS | PROBABILITIES | CLASS_LABELS
+    cat_policy      : tuple[str, ...] of allowed cat_policy values, or
+                      None for "no constraint" (default standard)
+    normalization   : str | None -- forced normalization or None
+    num_policy      : str | None -- forced num_policy or None
+    supports_hpo    : bool
+    supports_regression / supports_classification : bool
+    train_row_limit : int | None -- soft cap on training-set size (e.g.
+                      foundation models with limited context). The runner
+                      and HPO loops respect this when sampling.
+    notes           : str
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ----------------------------------------------------------------------------
+#  Enums
+# ----------------------------------------------------------------------------
+
+class Architecture(str, Enum):
+    DEEP = "deep"
+    CLASSICAL = "classical"
+
+
+class Hardware(str, Enum):
+    GPU = "gpu"
+    CPU = "cpu"
+
+
+class OutputType(str, Enum):
+    """What `predict()` returns for classification tasks.
+
+    Verified by reading each method's `predict()`:
+      - LOGITS:        raw network output, needs softmax/sigmoid externally
+      - PROBABILITIES: already in [0,1] summing to 1 (e.g. predict_proba)
+      - CLASS_LABELS:  hard predictions (regression-only methods, or models
+                       without probabilistic outputs)
+    """
+    LOGITS = "logits"
+    PROBABILITIES = "probabilities"
+    CLASS_LABELS = "class_labels"
+
+
+# Sentinel: the special cat_policy '!indices' in asserts means "anything
+# except indices". We encode this as the tuple of all *other* valid policies.
+_ALL_CAT_POLICIES = ("ordinal", "ohe", "binary", "hash", "loo", "target",
+                     "catboost", "tabr_ohe")  # everything except 'indices'
+
+
+# ----------------------------------------------------------------------------
+#  MethodSpec dataclass
+# ----------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class MethodSpec:
+    name: str
+    module: str
+    class_name: str
+    architecture: Architecture
+    hardware: Hardware
+    output_type: OutputType
+    cat_policy: Optional[Tuple[str, ...]] = None
+    normalization: Optional[str] = None
+    num_policy: Optional[str] = None
+    supports_hpo: bool = True
+    supports_regression: bool = True
+    supports_classification: bool = True
+    train_row_limit: Optional[int] = None
+    notes: str = ""
+
+    def get_class(self):
+        """Lazy-import the method class from its module."""
+        mod = importlib.import_module(self.module)
+        return getattr(mod, self.class_name)
+
+    def validate_args(self, args) -> None:
+        """Raise ValueError if `args` violates this spec's preprocessing
+        constraints. Used by the high-level runner to fail fast with a
+        readable message instead of an obscure `assert`.
+        """
+        problems: List[str] = []
+        if self.cat_policy is not None and getattr(args, 'cat_policy', None) not in self.cat_policy:
+            problems.append(
+                f"cat_policy must be one of {self.cat_policy}, got "
+                f"{getattr(args, 'cat_policy', None)!r}"
+            )
+        if self.normalization is not None and getattr(args, 'normalization', None) != self.normalization:
+            problems.append(
+                f"normalization must be {self.normalization!r}, got "
+                f"{getattr(args, 'normalization', None)!r}"
+            )
+        if self.num_policy is not None and getattr(args, 'num_policy', None) != self.num_policy:
+            problems.append(
+                f"num_policy must be {self.num_policy!r}, got "
+                f"{getattr(args, 'num_policy', None)!r}"
+            )
+        if not self.supports_hpo and getattr(args, 'tune', False):
+            problems.append(f"{self.name} does not support HPO (set tune=False)")
+        if problems:
+            raise ValueError(
+                f"Invalid args for method {self.name!r}:\n  - " + "\n  - ".join(problems)
+            )
+
+
+# ----------------------------------------------------------------------------
+#  Registry data
+# ----------------------------------------------------------------------------
+
+def _spec(name, module, class_name, architecture, hardware, output_type, **kw):
+    return MethodSpec(
+        name=name, module=module, class_name=class_name,
+        architecture=architecture, hardware=hardware, output_type=output_type,
+        **kw,
+    )
+
+
+# Convenience shortcuts to keep entries readable
+_DEEP = Architecture.DEEP
+_CLASSICAL = Architecture.CLASSICAL
+_GPU = Hardware.GPU
+_CPU = Hardware.CPU
+_LOGITS = OutputType.LOGITS
+_PROBS = OutputType.PROBABILITIES
+_LABELS = OutputType.CLASS_LABELS
+
+
+_METHODS_DEEP = [
+    # ----- Basic neural -----
+    _spec("mlp", "TALENT.model.methods.mlp", "MLPMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("resnet", "TALENT.model.methods.resnet", "ResNetMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("snn", "TALENT.model.methods.snn", "SNNMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("realmlp", "TALENT.model.methods.realmlp", "RealMLPMethod",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          notes="Classifier predict() returns predict_proba output."),
+    _spec("mlp_plr", "TALENT.model.methods.mlp_plr", "MLP_PLRMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("tabr_ohe",), num_policy=None),
+
+    # ----- Transformer-based -----
+    _spec("autoint", "TALENT.model.methods.autoint", "AutoIntMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("saint", "TALENT.model.methods.saint", "SaintMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("ftt", "TALENT.model.methods.ftt", "FTTMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("tabtransformer", "TALENT.model.methods.tabtransformer", "TabTransformerMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("excelformer", "TALENT.model.methods.excelformer", "ExcelFormerMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("t2gformer", "TALENT.model.methods.t2gformer", "T2GFormerMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("amformer", "TALENT.model.methods.amformer", "AMFormerMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("trompt", "TALENT.model.methods.trompt", "TromptMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+
+    # ----- Tree-mimic / specialized -----
+    _spec("dcn2", "TALENT.model.methods.dcn2", "DCN2Method",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("node", "TALENT.model.methods.node", "NodeMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("tabcaps", "TALENT.model.methods.tabcaps", "TabCapsMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES,
+          supports_regression=False),
+    _spec("tabnet", "TALENT.model.methods.tabnet", "TabNetMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("danets", "TALENT.model.methods.danets", "DANetsMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("grownet", "TALENT.model.methods.grownet", "GrowNetMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("grande", "TALENT.model.methods.grande", "GRANDEMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("tabm", "TALENT.model.methods.tabm", "TabMMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+
+    # ----- KNN-style -----
+    _spec("tabr", "TALENT.model.methods.tabr", "TabRMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("tabr_ohe",), num_policy="none"),
+    _spec("modernNCA", "TALENT.model.methods.modernNCA", "ModernNCAMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("tabr_ohe",), num_policy="none"),
+    _spec("dnnr", "TALENT.model.methods.dnnr", "DNNRMethod",
+          _DEEP, _GPU, _LABELS, cat_policy=_ALL_CAT_POLICIES,
+          supports_classification=False,
+          notes="Regression-only KNN-based method."),
+
+    # ----- Regularization-based -----
+    _spec("tangos", "TALENT.model.methods.tangos", "TangosMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("switchtab", "TALENT.model.methods.switchtab", "SwitchTabMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("ptarl", "TALENT.model.methods.ptarl", "PTARLMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("bishop", "TALENT.model.methods.bishop", "BiSHopMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("protogate", "TALENT.model.methods.protogate", "ProtoGateMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES,
+          supports_regression=False),
+    _spec("tabautopnpnet", "TALENT.model.methods.tabautopnpnet", "TabAutoPNPNetMethod",
+          _DEEP, _GPU, _LOGITS),
+
+    # ----- Foundation models -----
+    _spec("tabpfn", "TALENT.model.methods.tabpfn", "TabPFNMethod",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False, supports_regression=False,
+          train_row_limit=10_000,
+          notes="TabPFN v1 (bundled). 1k-10k samples; classification only."),
+    _spec("tabpfn_v2", "TALENT.model.methods.tabpfn_v2", "TabPFNMethod",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False, train_row_limit=10_000,
+          notes="TabPFN v2 (bundled, Nature 2025)."),
+    _spec("tabpfn_v3", "TALENT.model.methods.tabpfn_v3", "TabPFNv3Method",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False,
+          notes="TabPFN v3 (external `tabpfn>=8.0.0`). ~1M-row context."),
+    _spec("tabpfn_real", "TALENT.model.methods.tabpfn_real", "TabPFNRealMethod",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False, train_row_limit=10_000,
+          notes="Real-TabPFN (continued pre-training on real datasets)."),
+    _spec("hyperfast", "TALENT.model.methods.hyperfast", "HyperFastMethod",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False, supports_regression=False,
+          notes="HyperFast meta-trained hypernetwork; classification only."),
+    _spec("tabptm", "TALENT.model.methods.tabptm", "TabPTMMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("ohe",),
+          normalization="standard", num_policy="none",
+          supports_hpo=False),
+    _spec("tabicl", "TALENT.model.methods.tabicl", "TabICLMethod",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False, supports_regression=False,
+          notes="TabICL v1.1 (bundled); classification only — use tabicl_v2 for regression."),
+    _spec("tabicl_v2", "TALENT.model.methods.tabicl_v2", "TabICLv2Method",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False,
+          notes="TabICL v2 (external `tabicl>=2.0.0`); supports regression."),
+    _spec("mitra", "TALENT.model.methods.mitra", "MitraMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False,
+          notes="Mitra (Amazon Science). ICL with cross-attention; O(N_train * N_test) memory."),
+    _spec("limix", "TALENT.model.methods.limix", "LimiXMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False,
+          notes="LimiX tabular foundation model."),
+]
+
+
+_METHODS_CLASSICAL = [
+    _spec("dummy", "TALENT.model.classical_methods.dummy", "DummyMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES,
+          notes="Baseline: majority-class / mean predictor."),
+    _spec("LogReg", "TALENT.model.classical_methods.logreg", "LogRegMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES,
+          supports_regression=False),
+    _spec("LinearRegression", "TALENT.model.classical_methods.lr", "LinearRegressionMethod",
+          _CLASSICAL, _CPU, _LABELS, cat_policy=_ALL_CAT_POLICIES,
+          supports_classification=False, supports_hpo=False,
+          notes="Regression-only; returns point estimates."),
+    _spec("xgboost", "TALENT.model.classical_methods.xgboost", "XGBoostMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES,
+          notes="GPU-capable when CUDA available (see utils.tune_hyper_parameters)."),
+    _spec("catboost", "TALENT.model.classical_methods.catboost", "CatBoostMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=("indices",),
+          notes="Uses native categorical handling via cat_policy='indices'."),
+    _spec("lightgbm", "TALENT.model.classical_methods.lightgbm", "LightGBMMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("RandomForest", "TALENT.model.classical_methods.randomforest", "RandomForestMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("svm", "TALENT.model.classical_methods.svm", "SvmMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES,
+          notes="LinearSVC + CalibratedClassifierCV for probability calibration."),
+    _spec("knn", "TALENT.model.classical_methods.knn", "KnnMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES),
+    _spec("NCM", "TALENT.model.classical_methods.ncm", "NCMMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES,
+          supports_regression=False,
+          notes="Nearest class mean with softmax over negative distances."),
+    _spec("NaiveBayes", "TALENT.model.classical_methods.naivebayes", "NaiveBayesMethod",
+          _CLASSICAL, _CPU, _PROBS, cat_policy=_ALL_CAT_POLICIES,
+          supports_regression=False),
+    _spec("rfm", "TALENT.model.classical_methods.rfm", "RFMMethod",
+          _CLASSICAL, _GPU, _PROBS, cat_policy=("ohe",), normalization="standard",
+          notes="RFM (Recursive Feature Machines). GPU-accelerated kernel method."),
+    _spec("xrfm", "TALENT.model.classical_methods.xrfm", "XRFMMethod",
+          _CLASSICAL, _GPU, _PROBS, cat_policy=("ohe",), normalization="standard",
+          notes="xRFM (RFMs + adaptive tree structure)."),
+]
+
+
+# Master registry: name -> MethodSpec
+METHOD_REGISTRY: Dict[str, MethodSpec] = {
+    spec.name: spec for spec in (_METHODS_DEEP + _METHODS_CLASSICAL)
+}
+
+
+# ----------------------------------------------------------------------------
+#  Public lookup helpers
+# ----------------------------------------------------------------------------
+
+def get_method_spec(name: str) -> MethodSpec:
+    """Return the MethodSpec for `name`, or raise KeyError with a helpful list."""
+    if name not in METHOD_REGISTRY:
+        # Be lenient about case for a couple of historical name variants.
+        for canonical in METHOD_REGISTRY:
+            if canonical.lower() == name.lower():
+                return METHOD_REGISTRY[canonical]
+        raise KeyError(
+            f"Unknown method {name!r}. Available: "
+            f"{sorted(METHOD_REGISTRY.keys())}"
+        )
+    return METHOD_REGISTRY[name]
+
+
+def get_method_class(name: str):
+    """Return the method class (lazy import). Replaces the if/elif chain."""
+    return get_method_spec(name).get_class()
+
+
+def list_methods(
+    *,
+    architecture: Optional[Architecture] = None,
+    hardware: Optional[Hardware] = None,
+    supports_regression: Optional[bool] = None,
+    supports_classification: Optional[bool] = None,
+    supports_hpo: Optional[bool] = None,
+) -> List[MethodSpec]:
+    """List registered methods, optionally filtered by capability.
+
+    Each filter is applied only if the kwarg is non-None.
+    """
+    out: List[MethodSpec] = []
+    for spec in METHOD_REGISTRY.values():
+        if architecture is not None and spec.architecture != architecture:
+            continue
+        if hardware is not None and spec.hardware != hardware:
+            continue
+        if supports_regression is not None and spec.supports_regression != supports_regression:
+            continue
+        if supports_classification is not None and spec.supports_classification != supports_classification:
+            continue
+        if supports_hpo is not None and spec.supports_hpo != supports_hpo:
+            continue
+        out.append(spec)
+    return out
+
+
+def deep_method_names() -> List[str]:
+    """All deep-method names, in registration order. Used for argparse choices."""
+    return [s.name for s in _METHODS_DEEP]
+
+
+def classical_method_names() -> List[str]:
+    """All classical-method names, in registration order. Used for argparse choices."""
+    return [s.name for s in _METHODS_CLASSICAL]
+
+
+def all_method_names() -> List[str]:
+    return deep_method_names() + classical_method_names()

--- a/TALENT/model/utils.py
+++ b/TALENT/model/utils.py
@@ -276,12 +276,10 @@ def get_classical_args():
     parser = argparse.ArgumentParser()
     # basic parameters
     parser.add_argument('--dataset', type=str, default=default_args['dataset'])
+    from TALENT.model.method_registry import classical_method_names
     parser.add_argument('--model_type', type=str,
                         default=default_args['model_type'],
-                        choices=['dummy', 'LogReg', 'LinearRegression', 
-                                 'xgboost', 'catboost', 'lightgbm', 'RandomForest',
-                                 'svm', 'knn', 'NCM', 'NaiveBayes', 'rfm', 'xrfm',
-                                 ])
+                        choices=classical_method_names())
 
     # optimization parameters 
     parser.add_argument('--normalization', type=str, default=default_args['normalization'],
@@ -362,17 +360,9 @@ def get_deep_args():
     with pkg_resources.files(TALENT).joinpath("configs/deep_configs.json").open("r") as f:
         default_args = json.load(f)
     parser.add_argument('--dataset', type=str, default=default_args['dataset'])
+    from TALENT.model.method_registry import deep_method_names
     parser.add_argument('--model_type', type=str, default=default_args['model_type'],
-                        choices=['mlp', 'resnet', 'autoint', 'snn', 'ftt', 'dcn2', 'tabr',
-                                 'modernNCA', 'tabnet', 'node', 'tabcaps', 'saint', 'tangos',
-                                 'ptarl', 'danets', 'tabtransformer', 'grownet', 'dnnr',
-                                 'switchtab', 'bishop', 'protogate', 'realmlp', 'mlp_plr',
-                                 'excelformer', 'grande', 'amformer', 'trompt', 'tabm',
-                                 't2gformer', 'tabautopnpnet',
-
-                                 'tabpfn', 'tabpfn_v2', 'tabpfn_v3', 'tabpfn_real', 'hyperfast', 'tabptm',
-                                 'tabicl', 'tabicl_v2', 'mitra', 'limix',
-                                 ])
+                        choices=deep_method_names())
 
     # optimization parameters
     parser.add_argument('--max_epoch', type=int, default=default_args['max_epoch'])
@@ -745,175 +735,12 @@ def get_method(model):
 
     :model: str, model name
     :return: class, method class
-    """
-    
-    # Deep methods
-    
-    if model == "mlp":
-        from TALENT.model.methods.mlp import MLPMethod
-        return MLPMethod
-    elif model == 'resnet':
-        from TALENT.model.methods.resnet import ResNetMethod
-        return ResNetMethod
-    elif model == 'autoint':
-        from TALENT.model.methods.autoint import AutoIntMethod
-        return AutoIntMethod
-    elif model == 'snn':
-        from TALENT.model.methods.snn import SNNMethod
-        return SNNMethod
-    elif model == 'ftt':
-        from TALENT.model.methods.ftt import FTTMethod
-        return FTTMethod
-    elif model == 'dcn2':
-        from TALENT.model.methods.dcn2 import DCN2Method
-        return DCN2Method
-    elif model == 'tabr':
-        from TALENT.model.methods.tabr import TabRMethod
-        return TabRMethod
-    elif model == 'modernNCA':
-        from TALENT.model.methods.modernNCA import ModernNCAMethod
-        return ModernNCAMethod
-    elif model == 'tabnet':
-        from TALENT.model.methods.tabnet import TabNetMethod
-        return TabNetMethod
-    elif model == 'node':
-        from TALENT.model.methods.node import NodeMethod
-        return NodeMethod
-    elif model == 'tabcaps':
-        from TALENT.model.methods.tabcaps import TabCapsMethod
-        return TabCapsMethod
-    elif model == 'saint':
-        from TALENT.model.methods.saint import SaintMethod
-        return SaintMethod
-    elif model == 'tangos':
-        from TALENT.model.methods.tangos import TangosMethod
-        return TangosMethod
-    elif model == 'ptarl':
-        from TALENT.model.methods.ptarl import PTARLMethod
-        return PTARLMethod
-    elif model == 'danets':
-        from TALENT.model.methods.danets import DANetsMethod
-        return DANetsMethod
-    elif model == 'tabtransformer':
-        from TALENT.model.methods.tabtransformer import TabTransformerMethod
-        return TabTransformerMethod
-    elif model == 'grownet':
-        from TALENT.model.methods.grownet import GrowNetMethod
-        return GrowNetMethod
-    elif model == 'dnnr':
-        from TALENT.model.methods.dnnr import DNNRMethod
-        return DNNRMethod
-    elif model == 'switchtab':
-        from TALENT.model.methods.switchtab import SwitchTabMethod
-        return SwitchTabMethod
-    elif model == 'bishop':
-        from TALENT.model.methods.bishop import BiSHopMethod
-        return BiSHopMethod
-    elif model == 'protogate':
-        from TALENT.model.methods.protogate import ProtoGateMethod
-        return ProtoGateMethod
-    elif model == 'realmlp':
-        from TALENT.model.methods.realmlp import RealMLPMethod
-        return RealMLPMethod
-    elif model == 'mlp_plr':
-        from TALENT.model.methods.mlp_plr import MLP_PLRMethod
-        return MLP_PLRMethod
-    elif model == 'excelformer':
-        from TALENT.model.methods.excelformer import ExcelFormerMethod
-        return ExcelFormerMethod
-    elif model == 'grande':
-        from TALENT.model.methods.grande import GRANDEMethod
-        return GRANDEMethod
-    elif model == 'amformer':
-        from TALENT.model.methods.amformer import AMFormerMethod
-        return AMFormerMethod
-    elif model == 'trompt':
-        from TALENT.model.methods.trompt import TromptMethod
-        return TromptMethod
-    elif model == 'tabm':
-        from TALENT.model.methods.tabm import TabMMethod
-        return TabMMethod
-    elif model == 't2gformer':
-        from TALENT.model.methods.t2gformer import T2GFormerMethod
-        return T2GFormerMethod
-    elif model == 'tabautopnpnet':
-        from TALENT.model.methods.tabautopnpnet import TabAutoPNPNetMethod
-        return TabAutoPNPNetMethod
-    
-    # Classical methods
-    
-    elif model == 'dummy':
-        from TALENT.model.classical_methods.dummy import DummyMethod
-        return DummyMethod
-    elif model == 'LogReg':
-        from TALENT.model.classical_methods.logreg import LogRegMethod
-        return LogRegMethod
-    elif model == 'LinearRegression':
-        from TALENT.model.classical_methods.lr import LinearRegressionMethod
-        return LinearRegressionMethod
-    elif model == 'xgboost':
-        from TALENT.model.classical_methods.xgboost import XGBoostMethod
-        return XGBoostMethod
-    elif model == 'catboost':
-        from TALENT.model.classical_methods.catboost import CatBoostMethod
-        return CatBoostMethod
-    elif model == 'lightgbm':
-        from TALENT.model.classical_methods.lightgbm import LightGBMMethod
-        return LightGBMMethod
-    elif model == 'RandomForest':
-        from TALENT.model.classical_methods.randomforest import RandomForestMethod
-        return RandomForestMethod
-    elif model == 'svm':
-        from TALENT.model.classical_methods.svm import SvmMethod
-        return SvmMethod
-    elif model == 'knn':
-        from TALENT.model.classical_methods.knn import KnnMethod
-        return KnnMethod
-    elif model == 'NCM':
-        from TALENT.model.classical_methods.ncm import NCMMethod
-        return NCMMethod
-    elif model == 'NaiveBayes':
-        from TALENT.model.classical_methods.naivebayes import NaiveBayesMethod
-        return NaiveBayesMethod
-    elif model == 'rfm':
-        from TALENT.model.classical_methods.rfm import RFMMethod
-        return RFMMethod
-    elif model == 'xrfm':
-        from TALENT.model.classical_methods.xrfm import XRFMMethod
-        return XRFMMethod
 
-    # General methods
-    
-    elif model == 'tabpfn':
-        from TALENT.model.methods.tabpfn import TabPFNMethod
-        return TabPFNMethod
-    elif model == 'tabpfn_v2':
-        from TALENT.model.methods.tabpfn_v2 import TabPFNMethod
-        return TabPFNMethod
-    elif model == 'tabpfn_v3':
-        from TALENT.model.methods.tabpfn_v3 import TabPFNv3Method
-        return TabPFNv3Method
-    elif model == 'tabpfn_real':
-        from TALENT.model.methods.tabpfn_real import TabPFNRealMethod
-        return TabPFNRealMethod
-    elif model == 'hyperfast':
-        from TALENT.model.methods.hyperfast import HyperFastMethod
-        return HyperFastMethod
-    elif model == 'tabptm':
-        from TALENT.model.methods.tabptm import TabPTMMethod
-        return TabPTMMethod
-    elif model == 'tabicl':
-        from TALENT.model.methods.tabicl import TabICLMethod
-        return TabICLMethod
-    elif model == 'tabicl_v2':
-        from TALENT.model.methods.tabicl_v2 import TabICLv2Method
-        return TabICLv2Method
-    elif model == 'mitra':
-        from TALENT.model.methods.mitra import MitraMethod
-        return MitraMethod
-    elif model == 'limix':
-        from TALENT.model.methods.limix import LimiXMethod
-        return LimiXMethod
-    
-    else:
-        raise NotImplementedError("Model \"" + model + "\" not yet implemented")
+    Implementation: delegates to the unified registry in
+    ``TALENT.model.method_registry`` (single source of truth).
+    """
+    from TALENT.model.method_registry import get_method_class
+    try:
+        return get_method_class(model)
+    except KeyError as e:
+        raise NotImplementedError(str(e)) from None

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Welcome to **TALENT**, a benchmark with a comprehensive machine learning toolbox
 
 ## 📰 What's New
 
+- [2026-05]🌟 Add [TabPFN v3](https://github.com/PriorLabs/TabPFN) (PriorLabs 2026) and [TabICL v2](https://github.com/soda-inria/tabicl) (ICML 2026, regression support added).
 - [2026-03]🌟 We have updated the TALENT-extension datasets and results. [Link](https://box.nju.edu.cn/d/b7b23a19ee054aaba7b6/?p=%2F&mode=list)
 - [2025-11]🌟 Add [RFM](https://www.science.org/doi/10.1126/science.adi5639) (Science).
 - [2025-11]🌟 Add [Real-TabPFN](https://arxiv.org/abs/2507.03971).
@@ -152,6 +153,8 @@ TALENT integrates an extensive array of 30+ deep learning architectures for tabu
 38. **[Real-TabPFN](https://arxiv.org/abs/2507.03971)**: An enhanced tabular foundation model that extends TabPFNv2 through continued pre-training on real-world datasets for classification tasks. 
 39. **[RFM](https://www.science.org/doi/10.1126/science.adi5639)**: A non-deep, backpropagation-free feature learning algorithm, iteratively applies AGOP to a kernel machine to adaptively learn task-specific features.
 40. **[xRFM](https://arxiv.org/abs/2508.10053)**: A tabular model that combines RFMs with an adaptive tree structure, enabling it to learn features local to data subsets and scale log-linearly with the number of samples.
+41. **[TabPFN v3](https://github.com/PriorLabs/TabPFN)**: TabPFN v3 (PriorLabs 2026), with native context up to ~1M rows × 200 features, 160-class support, and an optional thinking mode. Requires `pip install -U 'tabpfn>=8.0.0'`.
+42. **[TabICL v2](https://github.com/soda-inria/tabicl)**: TabICL v2 (ICML 2026), now supporting both classification and regression (via `TabICLRegressor`), with native quantile regression. Requires `pip install -U 'tabicl>=2.0.0'`.
 
 
 🔧 If you want to check the **default hyperparameters and hyperparameter search spaces** of all methods, please visit:  
@@ -200,6 +203,45 @@ if __name__ == '__main__':
 ```bash
 python train_model_deep.py --model_type MODEL_NAME
 ```
+
+### 🐍 Python API (library mode)
+
+TALENT also exposes a library-style API alongside the CLI scripts, so you can call methods directly from Python or a Jupyter notebook without manipulating `sys.argv`:
+
+```python
+import TALENT
+from TALENT.model.lib.data import get_dataset
+
+train_val, test, info = get_dataset("your_dataset", "./data")
+
+# Single-seed run
+result = TALENT.run("tabpfn_v3", train_val, test, info)
+print(dict(zip(result.metric_names, result.metrics)))
+print("Fit time:", result.fit_time, "Predict time:", result.predict_time)
+
+# Multi-seed run with hyperparameter tuning
+result = TALENT.run("catboost", train_val, test, info, tune=True, n_trials=50, seed_num=3)
+print("Mean metrics:", dict(zip(result.metric_names, result.metrics_mean)))
+print("Std metrics:",  dict(zip(result.metric_names, result.metrics_std)))
+```
+
+Introspect or filter methods via the unified registry:
+
+```python
+# What does this method need?
+spec = TALENT.get_method_spec("tabicl_v2")
+print(spec.cat_policy, spec.normalization, spec.supports_regression, spec.supports_hpo)
+
+# List all GPU-only deep methods that support regression
+for s in TALENT.list_methods(
+    architecture=TALENT.Architecture.DEEP,
+    hardware=TALENT.Hardware.GPU,
+    supports_regression=True,
+):
+    print(s.name)
+```
+
+Both the CLI scripts and the Python API are backed by the same `MethodSpec` registry, so adding a new method requires only a single registry entry (see `TALENT/model/method_registry.py`).
 
 
 


### PR DESCRIPTION
# registry, and Python API

## Unified method registry — `model/method_registry.py`

`MethodSpec` dataclass with one entry per method (53 total: 40 deep + 13 classical) declaring `architecture`, `hardware`, `output_type` (LOGITS / PROBABILITIES / CLASS_LABELS), required `cat_policy` / `normalization` / `num_policy`, `supports_hpo`, `supports_regression`, `supports_classification`, `train_row_limit`.

Helpers: `get_method_spec`, `get_method_class` (lazy import), `list_methods(...)` with filters, `MethodSpec.validate_args(args)` (raises readable `ValueError` instead of obscure asserts).

Refactored callers (CLI behaviour unchanged):
- `utils.get_method()` shrinks from ~175-line if/elif chain to an 11-line registry delegate.
- argparse `choices` in `get_deep_args` / `get_classical_args` come from the registry.

Adding a new method now requires only a registry entry + configs.

## Python API — `TALENT/api.py`

Library-mode entry point, lazy-loaded via `TALENT/__init__.py` (so `import TALENT` does not pull in torch):

```python
import TALENT
from TALENT.model.lib.data import get_dataset

train_val, test, info = get_dataset("housing", "./data")
result = TALENT.run("tabpfn_v3", train_val, test, info)
print(dict(zip(result.metric_names, result.metrics)))

# Multi-seed + HPO
result = TALENT.run("catboost", train_val, test, info, tune=True, n_trials=50, seed_num=5)

# Introspect / filter
TALENT.get_method_spec("tabicl_v2")
TALENT.list_methods(architecture=TALENT.Architecture.DEEP, supports_regression=True)
```

Components: `RunResult` dataclass (stable shape for single- and multi-seed runs, with `metrics_mean` / `metrics_std`), `build_args(...)` (argparse-equivalent builder, applies spec constraints, validates upfront), `run(...)` (handles both deep 4-tuple and classical 3-tuple `predict()` returns uniformly), `run_from_dataset(...)`. CLI scripts unchanged.

## Docs

- `readme.md`: 2026-05 "What's New" entry; methods #41 (TabPFN v3) and #42 (TabICL v2); new "Python API (library mode)" subsection.
- `CONTRIBUTING.md`: "Adding New Methods" steps point to the registry.

Sphinx/RST coverage of the new API deferred to a follow-up PR.

## Compatibility

- ✅ All 53 methods still resolve via `utils.get_method(name)`; unknown names still raise `NotImplementedError`.
- ✅ `train_model_deep.py` / `train_model_classical.py` unchanged.
- ✅ Every registered method has default + opt_space configs.
- ✅ `import TALENT` works without torch.

