### PR TITLE
Add calibration metrics, threshold tuning, predict_proba standardization, and fix bundled paths

### DIFF
--- a/TALENT/api.py
+++ b/TALENT/api.py
@@ -75,8 +75,24 @@ from TALENT.model.method_registry import (
 class RunResult:
     """Output of a single :func:`run` call.
 
-    For single-seed runs, the `*_mean` / `*_std` fields are equal to the
-    single value and 0.0 respectively, so the API shape is stable.
+    For single-seed runs, the ``*_mean`` / ``*_std`` fields equal the
+    single value and ``0.0`` respectively, so the API shape is stable.
+
+    Notes on the prediction-related fields:
+
+    - ``predictions`` is the method's *raw* output (logits for some
+      methods, probabilities for others, regression scalars for regressors).
+      Regression predictions are returned on the **original target scale**
+      (i.e. denormalized).
+    - ``predict_proba`` is a uniform ``(N, K)`` probability array for
+      every classifier regardless of whether its native output is logits
+      or probabilities. ``None`` for regression and class-label-only
+      methods.
+    - ``predict_labels`` is the corresponding hard prediction. For binary
+      classification with threshold tuning, it uses the tuned threshold;
+      otherwise it uses ``argmax(predict_proba)``.
+    - ``threshold`` is the decision threshold tuned on the validation set
+      (binary classification only). ``None`` otherwise.
     """
     predictions: np.ndarray
     loss: float
@@ -91,6 +107,11 @@ class RunResult:
     metrics_mean: Tuple[float, ...] = field(default_factory=tuple)
     metrics_std: Tuple[float, ...] = field(default_factory=tuple)
     per_seed: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Standardized probabilistic output + tuned threshold (last seed)
+    predict_proba: Optional[np.ndarray] = None
+    predict_labels: Optional[np.ndarray] = None
+    threshold: Optional[float] = None
 
     # Bookkeeping
     method_type: str = ""
@@ -109,6 +130,7 @@ class RunResult:
             "metrics_std": dict(zip(self.metric_names, [float(x) for x in self.metrics_std])) if self.metrics_std else {},
             "fit_time": float(self.fit_time),
             "predict_time": float(self.predict_time),
+            "threshold": float(self.threshold) if self.threshold is not None else None,
             "save_path": self.save_path,
         }
         return d
@@ -327,6 +349,8 @@ def run(
     save_path: Optional[str] = None,
     return_method: bool = False,
     verbose: bool = False,
+    tune_threshold: bool = True,
+    threshold_metric: str = "f1",
     **arg_overrides,
 ) -> RunResult:
     """Fit a TALENT method on ``train_val_data`` and predict on ``test_data``.
@@ -366,6 +390,15 @@ def run(
         Adds RAM cost, so off by default.
     verbose : bool, default False
         Forwarded to the method when supported.
+    tune_threshold : bool, default True
+        For binary classification only: tune the decision threshold on
+        the validation split (already required by TALENT) to maximise the
+        ``threshold_metric``, and apply that threshold when computing
+        Accuracy / F1 / Avg_Recall / Avg_Precision. Threshold-independent
+        metrics (LogLoss, AUC, Brier, ECE) are unaffected. Has no effect
+        on regression or multiclass tasks.
+    threshold_metric : {"f1", "accuracy", "precision", "recall", "balanced_accuracy"}
+        Which metric to optimise when tuning the threshold. Default ``"f1"``.
     **arg_overrides
         Passed through to :func:`build_args`.
 
@@ -436,9 +469,17 @@ def run(
             )
         args = tune_hyper_parameters(args, opt_space, train_val_data, info)
 
+    # Use the centralized evaluator so the CLI scripts and the API share
+    # the exact same evaluation logic (predict_proba standardization +
+    # threshold tuning on val).
+    from TALENT.model.lib.evaluation import evaluate
+
     per_seed: List[Dict[str, Any]] = []
     last_predictions: Optional[np.ndarray] = None
     last_metric_names: Tuple[str, ...] = ()
+    last_predict_proba: Optional[np.ndarray] = None
+    last_predict_labels: Optional[np.ndarray] = None
+    last_threshold: Optional[float] = None
     fit_times: List[float] = []
     predict_times: List[float] = []
     method = None
@@ -459,20 +500,22 @@ def run(
         elif fit_time is None:
             fit_time = 0.0
 
-        ret = method.predict(test_data, info, model_name=args.evaluate_option)
-        # Deep methods return (vl, vres, metric_names, predictions);
-        # classical methods return (vres, metric_names, predictions).
-        if len(ret) == 4:
-            vl, vres, metric_names, preds = ret
-        elif len(ret) == 3:
-            vres, metric_names, preds = ret
-            vl = float("nan")
-        else:
-            raise RuntimeError(
-                f"Unexpected predict() return arity {len(ret)} for {model_type!r}"
-            )
+        eval_result = evaluate(
+            method,
+            train_val_data,
+            test_data,
+            info,
+            model_name=args.evaluate_option,
+            output_type=spec.output_type,
+            tune_threshold=tune_threshold,
+            threshold_metric=threshold_metric,
+        )
+        vl = eval_result["loss"]
+        vres = eval_result["metrics"]
+        metric_names = eval_result["metric_names"]
+        preds = eval_result["predictions"]
 
-        # Coerce to numpy if needed
+        # Coerce raw predictions to numpy (predict_proba / labels are already numpy).
         if hasattr(preds, "detach"):
             preds = preds.detach().cpu().numpy()
         preds = np.asarray(preds)
@@ -489,9 +532,15 @@ def run(
             "fit_time": float(fit_time),
             "predict_time": predict_time,
             "predictions": preds,
+            "predict_proba": eval_result["predict_proba"],
+            "predict_labels": eval_result["predict_labels"],
+            "threshold": eval_result["threshold"],
         })
         last_predictions = preds
         last_metric_names = tuple(metric_names)
+        last_predict_proba = eval_result["predict_proba"]
+        last_predict_labels = eval_result["predict_labels"]
+        last_threshold = eval_result["threshold"]
 
     # Aggregate
     if seed_num > 1:
@@ -504,6 +553,9 @@ def run(
 
     result = RunResult(
         predictions=last_predictions,
+        predict_proba=last_predict_proba,
+        predict_labels=last_predict_labels,
+        threshold=last_threshold,
         loss=per_seed[-1]["loss"],
         metrics=per_seed[-1]["metrics"],
         metric_names=last_metric_names,

--- a/TALENT/configs/default/tabdpt.json
+++ b/TALENT/configs/default/tabdpt.json
@@ -1,0 +1,13 @@
+{
+    "tabdpt": {
+        "model": {},
+        "training": {},
+        "general": {
+            "sample_size": 100000,
+            "n_ensembles": 8,
+            "context_size": 2048,
+            "temperature": 0.8,
+            "permute_classes": true
+        }
+    }
+}

--- a/TALENT/configs/default/tabpfn_v2_5.json
+++ b/TALENT/configs/default/tabpfn_v2_5.json
@@ -1,0 +1,11 @@
+{
+    "tabpfn_v2_5": {
+        "model": {},
+        "training": {},
+        "general": {
+            "sample_size": 50000,
+            "ignore_pretraining_limits": true,
+            "n_estimators": 8
+        }
+    }
+}

--- a/TALENT/configs/default/tabpfn_v3.json
+++ b/TALENT/configs/default/tabpfn_v3.json
@@ -3,9 +3,9 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 50000,
+            "sample_size": 1000000,
             "ignore_pretraining_limits": true,
-            "n_estimators": 4
+            "n_estimators": 32
         }
     }
 }

--- a/TALENT/configs/opt_space/tabdpt.json
+++ b/TALENT/configs/opt_space/tabdpt.json
@@ -1,0 +1,13 @@
+{
+    "tabdpt": {
+        "model": {},
+        "training": {},
+        "general": {
+            "sample_size": 100000,
+            "n_ensembles": 8,
+            "context_size": 2048,
+            "temperature": 0.8,
+            "permute_classes": true
+        }
+    }
+}

--- a/TALENT/configs/opt_space/tabpfn_v2_5.json
+++ b/TALENT/configs/opt_space/tabpfn_v2_5.json
@@ -1,0 +1,11 @@
+{
+    "tabpfn_v2_5": {
+        "model": {},
+        "training": {},
+        "general": {
+            "sample_size": 50000,
+            "ignore_pretraining_limits": true,
+            "n_estimators": 8
+        }
+    }
+}

--- a/TALENT/model/classical_methods/base.py
+++ b/TALENT/model/classical_methods/base.py
@@ -88,7 +88,15 @@ class classical_methods(object, metaclass=abc.ABCMeta):
         set_seeds(self.args.seed)
         self.config = self.args.config = config
 
-    def metric(self, predictions, labels, y_info):
+    def metric(self, predictions, labels, y_info, threshold=None):
+        """Compute evaluation metrics.
+
+        :param threshold: float or None. If given and the task is binary
+            classification, use ``predictions[:, 1] >= threshold`` for the
+            hard-prediction metrics (Accuracy, Avg_Recall, Avg_Precision,
+            F1). Threshold-independent metrics (LogLoss, AUC, Brier, ECE)
+            are not affected. Silently ignored for regression/multiclass.
+        """
         if not isinstance(labels, np.ndarray):
             labels = labels.cpu().numpy()
         if not isinstance(predictions, np.ndarray):
@@ -100,36 +108,52 @@ class classical_methods(object, metaclass=abc.ABCMeta):
             if y_info['policy'] == 'mean_std':
                 mae *= y_info['std']
                 rmse *= y_info['std']
-            return (mae,r2,rmse), ("MAE", "R2", "RMSE")
+            return (mae, r2, rmse), ("MAE", "R2", "RMSE")
         elif self.is_binclass:
-            # if not softmax, convert to probabilities
             predictions = check_softmax(predictions)
-            accuracy = skm.accuracy_score(labels, predictions.argmax(axis=-1))
-            avg_recall = skm.balanced_accuracy_score(labels, predictions.argmax(axis=-1))
-            avg_precision = skm.precision_score(labels, predictions.argmax(axis=-1), average='macro')
-            f1_score = skm.f1_score(labels, predictions.argmax(axis=-1), average='binary')
-            log_loss = skm.log_loss(labels, predictions)
-            auc = skm.roc_auc_score(labels, predictions[:, 1])
-            return (accuracy, avg_recall, avg_precision, f1_score, log_loss, auc), ("Accuracy", "Avg_Recall", "Avg_Precision", "F1", "LogLoss", "AUC")
-        elif self.is_multiclass:
-            # if not softmax, convert to probabilities
-            predictions = check_softmax(predictions)
-            accuracy = skm.accuracy_score(labels, predictions.argmax(axis=-1))
-            avg_recall = skm.balanced_accuracy_score(labels, predictions.argmax(axis=-1))
-            avg_precision = skm.precision_score(labels, predictions.argmax(axis=-1), average='macro')
-            f1_score = skm.f1_score(labels, predictions.argmax(axis=-1), average='macro')
+            if threshold is not None:
+                hard_preds = (predictions[:, 1] >= threshold).astype(int)
+            else:
+                hard_preds = predictions.argmax(axis=-1)
+            accuracy = skm.accuracy_score(labels, hard_preds)
+            avg_recall = skm.balanced_accuracy_score(labels, hard_preds)
+            avg_precision = skm.precision_score(labels, hard_preds, average='macro')
+            f1_score = skm.f1_score(labels, hard_preds, average='binary')
             log_loss = skm.log_loss(labels, predictions, labels=y_info['classes'])
-            
+            auc = skm.roc_auc_score(labels, predictions[:, 1], labels=y_info['classes']) if len(np.unique(labels)) == 2 else float("nan")
+            from TALENT.model.lib.calibration import brier_score, expected_calibration_error
+            brier = brier_score(labels, predictions)
+            ece = expected_calibration_error(labels, predictions)
+            return (
+                (accuracy, avg_recall, avg_precision, f1_score, log_loss, auc, brier, ece),
+                ("Accuracy", "Avg_Recall", "Avg_Precision", "F1", "LogLoss", "AUC", "Brier", "ECE"),
+            )
+        elif self.is_multiclass:
+            predictions = check_softmax(predictions)
+            hard_preds = predictions.argmax(axis=-1)
+            accuracy = skm.accuracy_score(labels, hard_preds)
+            avg_recall = skm.balanced_accuracy_score(labels, hard_preds)
+            avg_precision = skm.precision_score(labels, hard_preds, average='macro')
+            f1_score = skm.f1_score(labels, hard_preds, average='macro')
+            log_loss = skm.log_loss(labels, predictions, labels=y_info['classes'])
+
             present_classes = np.unique(labels)
             if len(present_classes) < 2:
                 auc = float("nan")
             else:
-                labels = label_binarize(labels, classes=y_info['classes'])
+                labels_bin = label_binarize(labels, classes=y_info['classes'])
                 class_indices = [i for i, c in enumerate(y_info['classes']) if c in present_classes]
-                predictions = predictions[:, class_indices]
-                labels = labels[:, class_indices]
-                auc = skm.roc_auc_score(labels, predictions, labels=present_classes, average='macro', multi_class='ovr')
-            
-            return (accuracy, avg_recall, avg_precision, f1_score, log_loss, auc), ("Accuracy", "Avg_Recall", "Avg_Precision", "F1", "LogLoss", "AUC")
+                preds_sliced = predictions[:, class_indices]
+                labels_bin = labels_bin[:, class_indices]
+                auc = skm.roc_auc_score(labels_bin, preds_sliced, labels=present_classes, average='macro', multi_class='ovr')
+
+            from TALENT.model.lib.calibration import brier_score, expected_calibration_error
+            brier = brier_score(labels, predictions)
+            ece = expected_calibration_error(labels, predictions)
+
+            return (
+                (accuracy, avg_recall, avg_precision, f1_score, log_loss, auc, brier, ece),
+                ("Accuracy", "Avg_Recall", "Avg_Precision", "F1", "LogLoss", "AUC", "Brier", "ECE"),
+            )
         else:
             raise ValueError("Unknown tabular task type")

--- a/TALENT/model/classical_methods/lr.py
+++ b/TALENT/model/classical_methods/lr.py
@@ -45,7 +45,9 @@ class LinearRegressionMethod(classical_methods):
             test_logit = test_logit * self.y_info['std'] + self.y_info['mean']
         return vres, metric_name, test_logit
     
-    def metric(self, predictions, labels, y_info):
+    def metric(self, predictions, labels, y_info, threshold=None):
+        # `threshold` accepted for signature compat with base.metric();
+        # silently ignored because LinearRegression is regression-only.
         if not isinstance(labels, np.ndarray):
             labels = labels.cpu().numpy()
         if not isinstance(predictions, np.ndarray):

--- a/TALENT/model/classical_methods/xrfm.py
+++ b/TALENT/model/classical_methods/xrfm.py
@@ -223,20 +223,7 @@ class XRFMMethod(classical_methods):
             test_output = test_output * self.y_info['std'] + self.y_info['mean']
         return vres, metric_name, test_output
     
-    def metric(self, predictions, labels, y_info):
-        from sklearn import metrics as skm
-        if self.is_regression:
-            mae = skm.mean_absolute_error(labels, predictions)
-            rmse = skm.mean_squared_error(labels, predictions) ** 0.5
-            r2 = skm.r2_score(labels, predictions)
-            if y_info['policy'] == 'mean_std':
-                mae *= y_info['std']
-                rmse *= y_info['std']
-            return (mae,r2,rmse), ("MAE", "R2", "RMSE")
-        else:
-            predicted_classes = np.argmax(predictions, axis=1)
-            accuracy = skm.accuracy_score(labels, predicted_classes)
-            avg_precision = skm.precision_score(labels, predicted_classes, average='binary' if self.is_binclass else 'macro')
-            avg_recall = skm.recall_score(labels, predicted_classes, average='binary' if self.is_binclass else 'macro')
-            f1_score = skm.f1_score(labels, predicted_classes, average='binary' if self.is_binclass else 'macro')
-            return (accuracy, avg_precision, avg_recall, f1_score), ("Accuracy", "Avg_Precision", "Avg_Recall", "F1")
+    # NOTE: metric() override removed -- xRFM now inherits the unified
+    # classical_methods.base.metric() so it gets ECE / Brier / LogLoss / AUC
+    # alongside the other classification metrics, and threshold tuning
+    # works the same way as for every other classifier in TALENT.

--- a/TALENT/model/lib/calibration.py
+++ b/TALENT/model/lib/calibration.py
@@ -1,0 +1,106 @@
+"""Calibration metrics for probabilistic classifiers.
+
+Both metrics here are reported as **lower-is-better**. Perfect calibration
+corresponds to a score of ``0.0``.
+
+* :func:`brier_score` — mean squared error between predicted probabilities
+  and one-hot encoded ground truth. For binary classification this reduces
+  to ``mean((p_pos - y)^2)``.
+* :func:`expected_calibration_error` — equal-width bin estimate of
+  :math:`E[|P(correct | confidence) - confidence|]`, the standard ECE
+  formulation used in (Guo et al., 2017).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _ensure_proba_array(predictions: np.ndarray) -> np.ndarray:
+    """Coerce ``predictions`` into an ``(N, K)`` probability array.
+
+    Accepts:
+      - 2D array of shape ``(N, K)`` -- returned as-is
+      - 1D array of shape ``(N,)`` -- interpreted as positive-class
+        probability of a binary task, expanded to ``(N, 2)``
+    """
+    predictions = np.asarray(predictions, dtype=np.float64)
+    if predictions.ndim == 1:
+        predictions = np.stack([1.0 - predictions, predictions], axis=1)
+    return predictions
+
+
+def brier_score(y_true: np.ndarray, y_proba: np.ndarray) -> float:
+    """Multi-class Brier score (lower is better; perfect = 0).
+
+    For binary classification with ``y_proba`` shape ``(N, 2)``, this is
+    equivalent to ``mean((y_proba[:, 1] - y_true) ** 2)``. For ``K``
+    classes the multi-class generalisation is
+    ``mean(sum((y_proba - one_hot(y_true)) ** 2, axis=1))``.
+
+    Parameters
+    ----------
+    y_true : (N,) ndarray
+        Ground-truth class indices (``0..K-1``).
+    y_proba : (N, K) ndarray
+        Predicted class probabilities. Each row should sum to ~1.0.
+    """
+    y_proba = _ensure_proba_array(y_proba)
+    y_true = np.asarray(y_true).astype(int).ravel()
+    n_classes = y_proba.shape[1]
+
+    if n_classes == 2:
+        # Faster path that matches the standard binary Brier definition.
+        return float(np.mean((y_proba[:, 1] - y_true) ** 2))
+
+    # Multi-class: sum of squared differences over the one-hot encoding.
+    one_hot = np.zeros_like(y_proba)
+    one_hot[np.arange(len(y_true)), y_true] = 1.0
+    return float(np.mean(np.sum((y_proba - one_hot) ** 2, axis=1)))
+
+
+def expected_calibration_error(
+    y_true: np.ndarray,
+    y_proba: np.ndarray,
+    n_bins: int = 15,
+) -> float:
+    """Expected Calibration Error (Guo et al., 2017; lower is better).
+
+    Buckets samples by predicted confidence (max class probability) into
+    ``n_bins`` equal-width bins on ``[0, 1]``, and reports the weighted
+    average gap between confidence and accuracy inside each bin.
+
+    Parameters
+    ----------
+    y_true : (N,) ndarray
+        Ground-truth class indices.
+    y_proba : (N, K) ndarray
+        Predicted class probabilities.
+    n_bins : int, default 15
+        Number of equal-width bins.
+    """
+    y_proba = _ensure_proba_array(y_proba)
+    y_true = np.asarray(y_true).astype(int).ravel()
+
+    confidences = np.max(y_proba, axis=1)
+    predictions = np.argmax(y_proba, axis=1)
+    accuracies = (predictions == y_true).astype(float)
+
+    bin_edges = np.linspace(0.0, 1.0, n_bins + 1)
+    n = len(y_true)
+    ece = 0.0
+
+    for i in range(n_bins):
+        lo, hi = bin_edges[i], bin_edges[i + 1]
+        # Closed upper edge on the last bin so confidence==1.0 is counted.
+        if i == n_bins - 1:
+            in_bin = (confidences >= lo) & (confidences <= hi)
+        else:
+            in_bin = (confidences >= lo) & (confidences < hi)
+        n_in = int(in_bin.sum())
+        if n_in > 0:
+            avg_conf = float(confidences[in_bin].mean())
+            avg_acc = float(accuracies[in_bin].mean())
+            ece += (n_in / n) * abs(avg_conf - avg_acc)
+
+    return float(ece)

--- a/TALENT/model/lib/evaluation.py
+++ b/TALENT/model/lib/evaluation.py
@@ -1,0 +1,237 @@
+"""High-level evaluation orchestrator used by both ``TALENT.api.run()`` and
+the CLI scripts ``train_model_deep.py`` / ``train_model_classical.py``.
+
+The orchestrator does three things on top of the raw ``method.predict()``
+call:
+
+1. **predict_proba standardization** -- converts the method's native
+   output (logits / probabilities / class labels) to a uniform ``(N, K)``
+   probability array using the ``output_type`` declared in the method
+   registry. Methods that return logits get a softmax / sigmoid applied;
+   methods that already return probabilities are passed through (with a
+   normalize-to-sum-one safety pass).
+2. **Threshold tuning on the validation set** -- for binary classification
+   only, predicts on the validation split, scans thresholds to maximise a
+   chosen metric (default F1), and applies that threshold when computing
+   the hard-prediction metrics (Accuracy / F1 / Precision / Recall /
+   balanced accuracy). Threshold-independent metrics (AUC, LogLoss, ECE,
+   Brier) are unaffected.
+3. **Metric recomputation** -- calls ``method.metric()`` again with the
+   tuned threshold so the returned tuple already reflects it. The result
+   is the single source of truth; downstream code does not need to know
+   about the threshold to interpret the metrics.
+
+Both ``threshold`` and ``predict_proba`` flow back to the caller so they
+can be inspected, persisted, or reused.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+
+# ----------------------------------------------------------------------------
+#  Helpers
+# ----------------------------------------------------------------------------
+
+def _val_as_test(train_val_data: Tuple[Any, Any, Any]) -> Tuple[Any, Any, Any]:
+    """Remap the validation split to look like a ``test`` split for
+    :meth:`Method.predict`. ``method.predict`` keys into ``['test']``
+    internally; we just relabel the dict.
+    """
+    N, C, y = train_val_data
+    N_test = {"test": N["val"]} if N is not None else None
+    C_test = {"test": C["val"]} if C is not None else None
+    y_test = {"test": y["val"]}
+    return (N_test, C_test, y_test)
+
+
+def _to_numpy(arr: Any) -> np.ndarray:
+    """Convert torch tensors / lists / numpy to a numpy array."""
+    if arr is None:
+        return None
+    if hasattr(arr, "detach"):
+        arr = arr.detach().cpu().numpy()
+    return np.asarray(arr)
+
+
+def standardize_predict_proba(
+    predictions: Any,
+    output_type,
+    is_regression: bool,
+) -> Optional[np.ndarray]:
+    """Coerce a method's raw prediction output to ``(N, K)`` probabilities.
+
+    Returns ``None`` for regression or for methods whose ``output_type``
+    is ``CLASS_LABELS`` (i.e. nothing to convert).
+
+    The conversion rules are:
+
+    * ``OutputType.PROBABILITIES``: already probabilities; we only re-normalize
+      rows in case of numerical drift.
+    * ``OutputType.LOGITS``: softmax (sigmoid for 1D binary logits).
+    * ``OutputType.CLASS_LABELS``: returns ``None``.
+    """
+    from TALENT.model.method_registry import OutputType
+
+    if is_regression or output_type == OutputType.CLASS_LABELS:
+        return None
+
+    arr = _to_numpy(predictions).astype(np.float64, copy=False)
+
+    if output_type == OutputType.PROBABILITIES:
+        if arr.ndim == 1:
+            # Positive-class probability for a binary task -> expand.
+            return np.stack([1.0 - arr, arr], axis=1)
+        # Numerical-drift safety: re-normalize so each row sums to 1.
+        s = arr.sum(axis=1, keepdims=True)
+        s = np.where(s == 0.0, 1.0, s)
+        return arr / s
+
+    # OutputType.LOGITS
+    if arr.ndim == 1:
+        # Sigmoid for a single binary logit.
+        sig = 1.0 / (1.0 + np.exp(-arr))
+        return np.stack([1.0 - sig, sig], axis=1)
+
+    # Softmax (numerically stabilised).
+    arr = arr - np.max(arr, axis=1, keepdims=True)
+    e = np.exp(arr)
+    return e / e.sum(axis=1, keepdims=True)
+
+
+# ----------------------------------------------------------------------------
+#  Main entry point
+# ----------------------------------------------------------------------------
+
+def evaluate(
+    method: Any,
+    train_val_data: Tuple[Any, Any, Any],
+    test_data: Tuple[Any, Any, Any],
+    info: Dict[str, Any],
+    model_name: str,
+    *,
+    output_type=None,
+    tune_threshold: bool = True,
+    threshold_metric: str = "f1",
+) -> Dict[str, Any]:
+    """Predict + (optionally) tune threshold on val + return enriched metrics.
+
+    Parameters
+    ----------
+    method : Method
+        A fitted ``Method`` instance (deep or classical).
+    train_val_data : (N, C, y)
+        Training/validation data tuple as returned by ``get_dataset``.
+        Each element is either ``None`` or a dict with ``'train'`` and
+        ``'val'`` keys.
+    test_data : (N, C, y)
+        Test data tuple. Each element is either ``None`` or a dict with
+        a ``'test'`` key.
+    info : dict
+        Dataset info (``task_type``, ``n_num_features``, ``n_cat_features``).
+    model_name : str
+        Checkpoint suffix passed to ``method.predict()`` (e.g. ``"best-val"``).
+    output_type : MethodSpec.OutputType, optional
+        Output type for this method, used to convert logits to probabilities.
+        If ``None``, ``predict_proba`` will not be returned.
+    tune_threshold : bool, default True
+        If True and the task is binary classification, tune the decision
+        threshold on the validation set.
+    threshold_metric : {"f1", "accuracy", "precision", "recall", "balanced_accuracy"}
+        Metric to optimise when tuning the threshold.
+
+    Returns
+    -------
+    result : dict
+        Keys: ``loss``, ``metrics``, ``metric_names``, ``predictions``,
+        ``predict_proba``, ``predict_labels``, ``threshold``.
+
+        - ``loss`` -- raw loss as returned by ``method.predict()``
+        - ``metrics`` / ``metric_names`` -- tuned-threshold metrics if
+          binclass + tune_threshold, otherwise the original metrics
+        - ``predictions`` -- raw method output (whatever ``predict()`` returned)
+        - ``predict_proba`` -- ``(N, K)`` ndarray of probabilities, or
+          ``None`` for regression / class-label methods
+        - ``predict_labels`` -- hard predictions consistent with the tuned
+          threshold (binclass) or ``argmax(predict_proba)`` otherwise
+        - ``threshold`` -- the tuned threshold, or ``None`` if not tuned
+    """
+    task = info.get("task_type")
+    is_regression = task == "regression"
+    is_binclass = task == "binclass"
+
+    # ------ 1. Predict on TEST ------------------------------------------------
+    test_result = method.predict(test_data, info, model_name=model_name)
+    if len(test_result) == 4:
+        vl, vres, metric_names, test_predictions = test_result
+    elif len(test_result) == 3:
+        vres, metric_names, test_predictions = test_result
+        vl = float("nan")
+    else:
+        raise RuntimeError(
+            f"Unexpected predict() return arity {len(test_result)} for "
+            f"{type(method).__name__!r}"
+        )
+
+    # Snapshot the test-time state -- a second predict() call below would
+    # overwrite ``method.y_test``.
+    test_labels = method.y_test if hasattr(method, "y_test") else None
+    y_info = method.y_info if hasattr(method, "y_info") else None
+
+    # ------ 2. Tune threshold on the validation set ---------------------------
+    threshold: Optional[float] = None
+
+    if is_binclass and tune_threshold:
+        try:
+            val_data = _val_as_test(train_val_data)
+            val_result = method.predict(val_data, info, model_name=model_name)
+            if len(val_result) == 4:
+                _, _, _, val_predictions = val_result
+            else:
+                _, _, val_predictions = val_result
+            val_labels = method.y_test if hasattr(method, "y_test") else None
+
+            val_proba = standardize_predict_proba(
+                val_predictions, output_type, is_regression=False
+            )
+            if val_proba is not None and val_proba.shape[1] == 2 and val_labels is not None:
+                from TALENT.model.lib.threshold import tune_threshold as _find_threshold
+                threshold, _ = _find_threshold(
+                    val_labels, val_proba, metric=threshold_metric
+                )
+
+                # Recompute the test-set metrics using the tuned threshold.
+                vres, metric_names = method.metric(
+                    test_predictions, test_labels, y_info, threshold=threshold
+                )
+        except Exception as exc:  # pragma: no cover -- defensive fallback
+            warnings.warn(
+                f"Threshold tuning failed ({exc!r}); "
+                f"falling back to argmax metrics."
+            )
+            threshold = None
+
+    # ------ 3. Build predict_proba / predict_labels --------------------------
+    test_proba = standardize_predict_proba(
+        test_predictions, output_type, is_regression=is_regression
+    )
+    predict_labels: Optional[np.ndarray] = None
+    if test_proba is not None:
+        if is_binclass and threshold is not None:
+            predict_labels = (test_proba[:, 1] >= threshold).astype(int)
+        else:
+            predict_labels = test_proba.argmax(axis=1)
+
+    return {
+        "loss": float(vl) if vl == vl else float("nan"),  # NaN-safe coercion
+        "metrics": tuple(vres),
+        "metric_names": tuple(metric_names),
+        "predictions": test_predictions,
+        "predict_proba": test_proba,
+        "predict_labels": predict_labels,
+        "threshold": threshold,
+    }

--- a/TALENT/model/lib/threshold.py
+++ b/TALENT/model/lib/threshold.py
@@ -1,0 +1,106 @@
+"""Threshold tuning for binary classification.
+
+Many real-world deployments tune the decision threshold on a held-out
+validation set rather than using the default ``argmax`` (i.e. ``0.5`` for
+binary classification). This is especially important for imbalanced
+datasets where the F1-optimal threshold is often far from ``0.5``.
+
+This module provides a single helper, :func:`tune_threshold`, that scans
+a dense grid (with extra resolution near 0 and 1 for highly imbalanced
+data) and returns the threshold that maximises a chosen metric.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple, Union
+
+import numpy as np
+
+
+def _positive_class_proba(y_proba: np.ndarray) -> np.ndarray:
+    """Coerce ``y_proba`` to a 1D positive-class probability array."""
+    y_proba = np.asarray(y_proba, dtype=np.float64)
+    if y_proba.ndim == 1:
+        return y_proba
+    if y_proba.ndim == 2 and y_proba.shape[1] == 2:
+        return y_proba[:, 1]
+    raise ValueError(
+        f"tune_threshold expects binary probabilities, got shape {y_proba.shape}."
+    )
+
+
+def tune_threshold(
+    y_true: np.ndarray,
+    y_proba: np.ndarray,
+    metric: str = "f1",
+    n_thresholds: int = 101,
+) -> Tuple[float, float]:
+    """Find the decision threshold that maximises ``metric`` on ``(y_true, y_proba)``.
+
+    Parameters
+    ----------
+    y_true : (N,) ndarray
+        Ground-truth binary labels in ``{0, 1}``.
+    y_proba : (N,) or (N, 2) ndarray
+        Predicted positive-class probability (or full ``(N, 2)`` proba
+        array, in which case column 1 is used).
+    metric : {"f1", "accuracy", "precision", "recall", "balanced_accuracy"}
+        Metric to optimise. Defaults to ``"f1"`` because it is meaningful
+        on imbalanced data and is the most common choice in tabular work.
+    n_thresholds : int, default 101
+        Number of thresholds in the mid-range ``[0.01, 0.99]`` grid. The
+        helper additionally adds 20 finely-spaced thresholds in each tail
+        ``[1e-4, 1e-2]`` and ``[0.99, 1 - 1e-4]`` to handle imbalanced
+        problems where the optimum is close to 0 or 1.
+
+    Returns
+    -------
+    (threshold, score) : Tuple[float, float]
+        Optimal threshold (``proba >= threshold`` predicts class 1) and
+        the achieved score for that threshold.
+    """
+    from sklearn.metrics import (
+        f1_score,
+        accuracy_score,
+        precision_score,
+        recall_score,
+        balanced_accuracy_score,
+    )
+
+    pos_proba = _positive_class_proba(y_proba)
+    y_true = np.asarray(y_true).astype(int).ravel()
+
+    metric_fns = {
+        "f1": lambda y_t, y_p: f1_score(y_t, y_p, zero_division=0),
+        "accuracy": accuracy_score,
+        "precision": lambda y_t, y_p: precision_score(y_t, y_p, zero_division=0),
+        "recall": lambda y_t, y_p: recall_score(y_t, y_p, zero_division=0),
+        "balanced_accuracy": balanced_accuracy_score,
+    }
+    if metric not in metric_fns:
+        raise ValueError(
+            f"Unknown metric {metric!r}. Choose one of {sorted(metric_fns)}."
+        )
+    metric_fn = metric_fns[metric]
+
+    # Dense grid in the middle, fine-grained tails for highly imbalanced data.
+    thresholds = np.unique(
+        np.concatenate(
+            [
+                np.linspace(1e-4, 1e-2, 20),
+                np.linspace(0.01, 0.99, n_thresholds),
+                np.linspace(0.99, 1.0 - 1e-4, 20),
+            ]
+        )
+    )
+
+    best_score = -np.inf
+    best_t = 0.5
+    for t in thresholds:
+        y_pred = (pos_proba >= t).astype(int)
+        score = float(metric_fn(y_true, y_pred))
+        if score > best_score:
+            best_score = score
+            best_t = float(t)
+
+    return best_t, float(best_score)

--- a/TALENT/model/method_registry.py
+++ b/TALENT/model/method_registry.py
@@ -275,6 +275,12 @@ _METHODS_DEEP = [
           normalization="none", num_policy="none",
           supports_hpo=False, train_row_limit=10_000,
           notes="TabPFN v2 (bundled, Nature 2025)."),
+    _spec("tabpfn_v2_5", "TALENT.model.methods.tabpfn_v2_5", "TabPFNv2_5Method",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False, train_row_limit=50_000,
+          notes="TabPFN v2.5 (PriorLabs Nov 2025; external `tabpfn>=8.0.0`). "
+                "~50k rows x 2k features native context."),
     _spec("tabpfn_v3", "TALENT.model.methods.tabpfn_v3", "TabPFNv3Method",
           _DEEP, _GPU, _PROBS, cat_policy=("indices",),
           normalization="none", num_policy="none",
@@ -314,6 +320,12 @@ _METHODS_DEEP = [
           normalization="none", num_policy="none",
           supports_hpo=False,
           notes="LimiX tabular foundation model."),
+    _spec("tabdpt", "TALENT.model.methods.tabdpt", "TabDPTMethod",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False,
+          notes="TabDPT (Layer 6 AI). ICL + retrieval; supports both "
+                "classification and regression. External `tabdpt` package."),
 ]
 
 

--- a/TALENT/model/method_registry.py
+++ b/TALENT/model/method_registry.py
@@ -36,9 +36,43 @@ Schema:
 from __future__ import annotations
 
 import importlib
+import importlib.resources as _pkg_resources
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
+
+
+# ----------------------------------------------------------------------------
+#  Bundled-resource resolution
+# ----------------------------------------------------------------------------
+
+def resolve_bundled_path(relative: str) -> Optional[str]:
+    """Resolve a path relative to the installed ``TALENT`` package.
+
+    Returns the absolute filesystem path if the resource exists, or
+    ``None`` otherwise. Use this for bundled checkpoints and configs so
+    that the package keeps working regardless of the user's current
+    working directory (the historical hardcoded ``"./TALENT/..."`` paths
+    only worked when run from the repository root).
+
+    Example::
+
+        path = resolve_bundled_path("model/models/models_tabpfn/tabpfn-v2-classifier.ckpt")
+        # -> "/site-packages/TALENT/model/models/models_tabpfn/tabpfn-v2-classifier.ckpt"
+        #    or None if not bundled (auto-download fallback)
+    """
+    try:
+        import TALENT
+        p = _pkg_resources.files(TALENT).joinpath(relative)
+        # `Traversable` may be a filesystem path or a zipfile entry; convert
+        # to str and check existence on the filesystem (not in a zip).
+        path_str = str(p)
+        if os.path.exists(path_str):
+            return path_str
+    except Exception:
+        pass
+    return None
 
 
 # ----------------------------------------------------------------------------
@@ -223,8 +257,9 @@ _METHODS_DEEP = [
     _spec("bishop", "TALENT.model.methods.bishop", "BiSHopMethod",
           _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
     _spec("protogate", "TALENT.model.methods.protogate", "ProtoGateMethod",
-          _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES,
-          supports_regression=False),
+          _DEEP, _GPU, _LABELS, cat_policy=_ALL_CAT_POLICIES,
+          supports_regression=False,
+          notes="ProtoGate predict() returns hard class labels, not probabilities."),
     _spec("tabautopnpnet", "TALENT.model.methods.tabautopnpnet", "TabAutoPNPNetMethod",
           _DEEP, _GPU, _LOGITS),
 

--- a/TALENT/model/methods/base.py
+++ b/TALENT/model/methods/base.py
@@ -318,14 +318,22 @@ class Method(object, metaclass=abc.ABCMeta):
         torch.save(self.trlog, osp.join(self.args.save_path, 'trlog'))   
 
 
-    def metric(self, predictions, labels, y_info):
+    def metric(self, predictions, labels, y_info, threshold=None):
         """
         Compute the evaluation metric.
 
         :param predictions: np.ndarray, predictions
         :param labels: np.ndarray, labels
         :param y_info: dict, information about the labels
-        :return: tuple, (metric, metric_name)
+        :param threshold: float or None. If given **and** the task is binary
+            classification, use ``predictions[:, 1] >= threshold`` for the
+            hard-prediction metrics (Accuracy, Avg_Recall, Avg_Precision,
+            F1). Threshold-independent metrics (LogLoss, AUC, Brier, ECE)
+            are not affected. Silently ignored for regression/multiclass.
+        :return: tuple, (metric, metric_name). For classification, the
+            tuple includes Brier and ECE in addition to the existing
+            metrics; they are appended at the end so positional access of
+            existing fields is preserved.
         """
         if not isinstance(labels, np.ndarray):
             labels = labels.cpu().numpy()
@@ -338,36 +346,57 @@ class Method(object, metaclass=abc.ABCMeta):
             if y_info['policy'] == 'mean_std':
                 mae *= y_info['std']
                 rmse *= y_info['std']
-            return (mae,r2,rmse), ("MAE", "R2", "RMSE")
+            return (mae, r2, rmse), ("MAE", "R2", "RMSE")
         elif self.is_binclass:
-            # if not softmax, convert to probabilities
+            # If not already in [0,1] summing to 1, convert.
             predictions = check_softmax(predictions)
-            accuracy = skm.accuracy_score(labels, predictions.argmax(axis=-1))
-            avg_recall = skm.balanced_accuracy_score(labels, predictions.argmax(axis=-1))
-            avg_precision = skm.precision_score(labels, predictions.argmax(axis=-1), average='macro')
-            f1_score = skm.f1_score(labels, predictions.argmax(axis=-1), average='binary')
+            # Hard predictions: prefer the user-supplied threshold; else argmax.
+            if threshold is not None:
+                hard_preds = (predictions[:, 1] >= threshold).astype(int)
+            else:
+                hard_preds = predictions.argmax(axis=-1)
+            accuracy = skm.accuracy_score(labels, hard_preds)
+            avg_recall = skm.balanced_accuracy_score(labels, hard_preds)
+            avg_precision = skm.precision_score(labels, hard_preds, average='macro')
+            f1_score = skm.f1_score(labels, hard_preds, average='binary')
             log_loss = skm.log_loss(labels, predictions, labels=y_info['classes'])
             auc = skm.roc_auc_score(labels, predictions[:, 1], labels=y_info['classes']) if len(np.unique(labels)) == 2 else float("nan")
-            return (accuracy, avg_recall, avg_precision, f1_score, log_loss, auc), ("Accuracy", "Avg_Recall", "Avg_Precision", "F1", "LogLoss", "AUC")
+            # Calibration metrics (threshold-independent).
+            from TALENT.model.lib.calibration import brier_score, expected_calibration_error
+            brier = brier_score(labels, predictions)
+            ece = expected_calibration_error(labels, predictions)
+            return (
+                (accuracy, avg_recall, avg_precision, f1_score, log_loss, auc, brier, ece),
+                ("Accuracy", "Avg_Recall", "Avg_Precision", "F1", "LogLoss", "AUC", "Brier", "ECE"),
+            )
         elif self.is_multiclass:
             # if not softmax, convert to probabilities
             predictions = check_softmax(predictions)
-            accuracy = skm.accuracy_score(labels, predictions.argmax(axis=-1))
-            avg_recall = skm.balanced_accuracy_score(labels, predictions.argmax(axis=-1))
-            avg_precision = skm.precision_score(labels, predictions.argmax(axis=-1), average='macro')
-            f1_score = skm.f1_score(labels, predictions.argmax(axis=-1), average='macro')
+            hard_preds = predictions.argmax(axis=-1)
+            accuracy = skm.accuracy_score(labels, hard_preds)
+            avg_recall = skm.balanced_accuracy_score(labels, hard_preds)
+            avg_precision = skm.precision_score(labels, hard_preds, average='macro')
+            f1_score = skm.f1_score(labels, hard_preds, average='macro')
             log_loss = skm.log_loss(labels, predictions, labels=y_info['classes'])
-            
+
             present_classes = np.unique(labels)
             if len(present_classes) < 2:
                 auc = float("nan")
             else:
-                labels = label_binarize(labels, classes=y_info['classes'])
+                labels_bin = label_binarize(labels, classes=y_info['classes'])
                 class_indices = [i for i, c in enumerate(y_info['classes']) if c in present_classes]
-                predictions = predictions[:, class_indices]
-                labels = labels[:, class_indices]
-                auc = skm.roc_auc_score(labels, predictions, labels=present_classes, average='macro', multi_class='ovr')
-            
-            return (accuracy, avg_recall, avg_precision, f1_score, log_loss, auc), ("Accuracy", "Avg_Recall", "Avg_Precision", "F1", "LogLoss", "AUC")
+                preds_sliced = predictions[:, class_indices]
+                labels_bin = labels_bin[:, class_indices]
+                auc = skm.roc_auc_score(labels_bin, preds_sliced, labels=present_classes, average='macro', multi_class='ovr')
+
+            # Calibration metrics (use full-class probability vector).
+            from TALENT.model.lib.calibration import brier_score, expected_calibration_error
+            brier = brier_score(labels, predictions)
+            ece = expected_calibration_error(labels, predictions)
+
+            return (
+                (accuracy, avg_recall, avg_precision, f1_score, log_loss, auc, brier, ece),
+                ("Accuracy", "Avg_Recall", "Avg_Precision", "F1", "LogLoss", "AUC", "Brier", "ECE"),
+            )
         else:
             raise ValueError("Unknown tabular task type")

--- a/TALENT/model/methods/limix.py
+++ b/TALENT/model/methods/limix.py
@@ -44,8 +44,19 @@ class LimiXMethod(Method):
 
     def construct_model(self, model_config = None):
         from TALENT.model.models.limix import LimiXPredictor
-        model_path = "./TALENT/model/models/models_limix/LimiX-16M.ckpt"
-        config_path = f"./TALENT/model/lib/limix/config/{'reg' if self.is_regression else 'cls'}_default_noretrieval.json"
+        from TALENT.model.method_registry import resolve_bundled_path
+        cfg_name = ("reg" if self.is_regression else "cls") + "_default_noretrieval.json"
+        # Resolve bundled checkpoint + inference config via importlib.resources
+        # so the package works from any CWD; fall back to legacy relative path
+        # so behaviour from the repo root is preserved.
+        model_path = (
+            resolve_bundled_path("model/models/models_limix/LimiX-16M.ckpt")
+            or "./TALENT/model/models/models_limix/LimiX-16M.ckpt"
+        )
+        config_path = (
+            resolve_bundled_path(f"model/lib/limix/config/{cfg_name}")
+            or f"./TALENT/model/lib/limix/config/{cfg_name}"
+        )
         self.model = LimiXPredictor(
             device = self.args.device,
             model_path = model_path,

--- a/TALENT/model/methods/mitra.py
+++ b/TALENT/model/methods/mitra.py
@@ -44,10 +44,14 @@ class MitraMethod(Method):
 
     def construct_model(self, model_config = None):
         from TALENT.model.models.mitra import Mitra
-        if self.is_regression:
-            model_path = "./TALENT/model/models/models_mitra/reg/"
-        else:
-            model_path = "./TALENT/model/models/models_mitra/cls/"
+        from TALENT.model.method_registry import resolve_bundled_path
+        subdir = "reg" if self.is_regression else "cls"
+        # Resolve via importlib.resources so the package works from any CWD.
+        model_path = resolve_bundled_path(f"model/models/models_mitra/{subdir}/")
+        if model_path is None:
+            # Fall back to the legacy relative path -- preserves prior
+            # behaviour when running from the repository root.
+            model_path = f"./TALENT/model/models/models_mitra/{subdir}/"
         self.model = Mitra.from_pretrained(
             path=model_path,
             device="cpu"  # safe tensor initialization on CPU

--- a/TALENT/model/methods/protogate.py
+++ b/TALENT/model/methods/protogate.py
@@ -215,7 +215,12 @@ class ProtoGateMethod(Method):
                 self.continue_training = False
         torch.save(self.trlog, osp.join(self.args.save_path, 'trlog'))   
 
-    def metric(self, predictions, labels, y_info):
+    def metric(self, predictions, labels, y_info, threshold=None):
+        # ProtoGate's predict() returns hard class labels (not probabilities
+        # or logits), so this override keeps the original 4-metric classification
+        # output. The `threshold` parameter is accepted for signature compat
+        # with the new base.metric() but is silently ignored: there is no
+        # probability vector to apply a threshold to.
         if not isinstance(labels, np.ndarray):
             labels = labels.cpu().numpy()
         if not isinstance(predictions, np.ndarray):

--- a/TALENT/model/methods/tabdpt.py
+++ b/TALENT/model/methods/tabdpt.py
@@ -1,0 +1,213 @@
+"""TabDPT method.
+
+TabDPT (`Layer 6 AI <https://github.com/layer6ai-labs/TabDPT-inference>`_)
+is a tabular foundation model that combines in-context learning with
+retrieval and self-supervised pre-training on real data. Unlike TabPFN /
+TabICL it does not have a hard context-size limit -- the retrieval step
+selects the most relevant rows from the training set for each query.
+
+The wrapper uses the upstream ``tabdpt`` package (sklearn-compatible
+API: ``TabDPTClassifier`` / ``TabDPTRegressor``) and exposes the runtime
+parameters (``n_ensembles``, ``context_size``, ``temperature``) through
+``config['general']`` so they can be tuned without code changes.
+
+Setup:
+    pip install -U tabdpt
+"""
+
+from TALENT.model.methods.base import Method
+import torch
+import numpy as np
+import torch.nn.functional as F
+
+from TALENT.model.lib.data import (
+    Dataset,
+    data_nan_process,
+    data_enc_process,
+    data_label_process,
+)
+import time
+
+
+class TabDPTMethod(Method):
+    """TabDPT (tabular foundation model with retrieval + ICL)."""
+
+    def __init__(self, args, is_regression):
+        super().__init__(args, is_regression)
+        # TabDPT does its own internal preprocessing, so we keep the
+        # outer pipeline minimal -- same convention as tabpfn_v2 /
+        # tabicl / mitra / limix.
+        assert args.normalization == 'none'
+        assert args.cat_policy == 'indices'
+        assert args.num_policy == 'none'
+        assert args.tune is not True
+
+    def data_format(self, is_train=True, N=None, C=None, y=None):
+        if is_train:
+            self.N, self.C, self.num_new_value, self.imputer, self.cat_new_value = data_nan_process(
+                self.N, self.C, self.args.num_nan_policy, self.args.cat_nan_policy
+            )
+            self.y, self.y_info, self.label_encoder = data_label_process(self.y, self.is_regression)
+            self.N, self.C, self.ord_encoder, self.mode_values, self.cat_encoder = data_enc_process(
+                self.N, self.C, self.args.cat_policy
+            )
+            self.criterion = F.cross_entropy if not self.is_regression else F.mse_loss
+        else:
+            N_test, C_test, _, _, _ = data_nan_process(
+                N, C, self.args.num_nan_policy, self.args.cat_nan_policy,
+                self.num_new_value, self.imputer, self.cat_new_value
+            )
+            N_test, C_test, _, _, _ = data_enc_process(
+                N_test, C_test, self.args.cat_policy, None,
+                self.ord_encoder, self.mode_values, self.cat_encoder
+            )
+            y_test, _, _ = data_label_process(y, self.is_regression, self.y_info, self.label_encoder)
+            if N_test is not None and C_test is not None:
+                self.N_test, self.C_test = N_test['test'], C_test['test']
+            elif N_test is None and C_test is not None:
+                self.N_test, self.C_test = None, C_test['test']
+            else:
+                self.N_test, self.C_test = N_test['test'], None
+            self.y_test = y_test['test']
+
+    def construct_model(self, model_config=None, cat_indices=None):
+        try:
+            from tabdpt import TabDPTClassifier, TabDPTRegressor
+        except ImportError as e:
+            raise ImportError(
+                "TabDPT requires the `tabdpt` package. "
+                "Install it via: pip install -U tabdpt"
+            ) from e
+
+        # TabDPT's constructors take few arguments at __init__ time --
+        # most runtime knobs (n_ensembles, context_size, temperature, ...)
+        # are passed to predict(). Persist them on self for later.
+        general = self.args.config.get('general', {}) or {}
+        self._predict_kwargs = {
+            "n_ensembles": general.get("n_ensembles", 8 if not self.is_regression else 2),
+            "context_size": general.get("context_size", 2048),
+            "seed": general.get("seed", self.args.seed),
+        }
+        if not self.is_regression:
+            # Classification-only knobs
+            self._predict_kwargs.setdefault("temperature", general.get("temperature", 0.8))
+            self._predict_kwargs.setdefault(
+                "permute_classes", general.get("permute_classes", True)
+            )
+
+        if self.is_regression:
+            self.model = TabDPTRegressor()
+        else:
+            self.model = TabDPTClassifier()
+
+    def fit(self, data, info, train=True, config=None):
+        N, C, y = data
+        self.D = Dataset(N, C, y, info)
+        self.N, self.C, self.y = self.D.N, self.D.C, self.D.y
+        self.is_binclass, self.is_multiclass, self.is_regression = (
+            self.D.is_binclass, self.D.is_multiclass, self.D.is_regression
+        )
+        self.data_format(is_train=True)
+
+        sampled_Y = self.y['train']
+        cat_indices = []
+        if self.N is not None and self.C is not None:
+            sampled_X = np.concatenate((self.N['train'], self.C['train']), axis=1)
+            n_num = self.N['train'].shape[1]
+            cat_indices = list(range(n_num, n_num + self.C['train'].shape[1]))
+        elif self.N is None and self.C is not None:
+            sampled_X = self.C['train']
+            cat_indices = list(range(self.C['train'].shape[1]))
+        else:
+            sampled_X = self.N['train']
+
+        # Optional sample_size cap. TabDPT scales via retrieval so it can
+        # generally handle large train sets, but the cap is exposed for
+        # benchmarking / time-budget consistency with other methods.
+        general = self.args.config.get('general', {}) or {}
+        sample_size = general.get('sample_size', None)
+        if sample_size is not None and sampled_X.shape[0] > sample_size:
+            if not self.is_regression:
+                from sklearn.model_selection import train_test_split
+                sampled_X, _, sampled_Y, _ = train_test_split(
+                    sampled_X, sampled_Y,
+                    train_size=sample_size,
+                    stratify=sampled_Y,
+                    random_state=self.args.seed,
+                )
+            else:
+                rng = np.random.RandomState(self.args.seed)
+                idx = rng.choice(sampled_X.shape[0], size=sample_size, replace=False)
+                sampled_X = sampled_X[idx]
+                sampled_Y = sampled_Y[idx]
+
+        self.sampled_X = sampled_X
+        self.sampled_Y = sampled_Y
+        self.construct_model(cat_indices=cat_indices)
+
+        tic = time.time()
+        self.model.fit(sampled_X, sampled_Y)
+        self.fit_time = time.time() - tic
+
+    def _predict_safely(self, X):
+        """Call ``model.predict`` / ``predict_proba`` with the runtime knobs
+        we cached at construct time. Falls back gracefully if the upstream
+        signature does not accept one of our kwargs.
+        """
+        if self.is_regression:
+            try:
+                return self.model.predict(X, **self._predict_kwargs)
+            except TypeError:
+                return self.model.predict(X)
+        # Classification -- prefer predict_proba for calibrated probabilities.
+        if hasattr(self.model, "predict_proba"):
+            try:
+                return self.model.predict_proba(X, **self._predict_kwargs)
+            except TypeError:
+                try:
+                    return self.model.predict_proba(X)
+                except Exception:
+                    pass
+        # Fallback: predict() returns class labels; manufacture one-hot.
+        try:
+            preds = self.model.predict(X, **self._predict_kwargs)
+        except TypeError:
+            preds = self.model.predict(X)
+        preds = np.asarray(preds).astype(int)
+        n_classes = int(self.y_info.get('n_classes', 2))
+        one_hot = np.zeros((len(preds), n_classes), dtype=np.float32)
+        one_hot[np.arange(len(preds)), preds] = 1.0
+        return one_hot
+
+    def predict(self, data, info, model_name):
+        N, C, y = data
+        self.data_format(False, N, C, y)
+        if self.N_test is not None and self.C_test is not None:
+            Test_X = np.concatenate((self.N_test, self.C_test), axis=1)
+        elif self.N_test is None and self.C_test is not None:
+            Test_X = self.C_test
+        else:
+            Test_X = self.N_test
+
+        tic = time.time()
+        test_logit = self._predict_safely(Test_X)
+        self.predict_time = time.time() - tic
+
+        test_logit = np.asarray(test_logit).astype(np.float32)
+        test_label = self.y_test
+        if self.is_regression:
+            t_pred = torch.tensor(test_logit).reshape(-1)
+            t_lab = torch.tensor(test_label, dtype=torch.float32).reshape(-1)
+            vl = self.criterion(t_pred, t_lab).item()
+        else:
+            vl = self.criterion(torch.tensor(test_logit), torch.tensor(test_label)).item()
+        vres, metric_name = self.metric(test_logit, test_label, self.y_info)
+
+        # Denormalize regression predictions for the returned value
+        if self.is_regression and self.y_info.get('policy') == 'mean_std':
+            test_logit = test_logit * self.y_info['std'] + self.y_info['mean']
+
+        print('Test: loss={:.4f}'.format(vl))
+        for name, res in zip(metric_name, vres):
+            print('[{}]={:.4f}'.format(name, res))
+        return vl, vres, metric_name, test_logit

--- a/TALENT/model/methods/tabicl.py
+++ b/TALENT/model/methods/tabicl.py
@@ -60,11 +60,17 @@ class TabICLMethod(Method):
 
     def construct_model(self, model_config = None,cat_indices=[]):
             from TALENT.model.lib.tabicl.classifier import TabICLClassifier
+            from TALENT.model.method_registry import resolve_bundled_path
+            # Use bundled checkpoint if present; otherwise the TabICL library
+            # auto-downloads via `model_path=None` + `allow_auto_download=True`.
+            model_path = resolve_bundled_path(
+                "model/models/models_tabicl/tabicl-classifier-v1.1-0506.ckpt"
+            )
             self.model = TabICLClassifier(
                 device=self.args.device,
                 random_state=self.args.seed,
                 checkpoint_version="tabicl-classifier-v1.1-0506.ckpt",
-                model_path="./TALENT/model/models/models_tabicl/tabicl-classifier-v1.1-0506.ckpt",
+                model_path=model_path,
                 n_estimators=32,                  # number of ensemble members
                 norm_methods=["none", "power"],   # normalization methods to try
                 feat_shuffle_method="latin",      # feature permutation strategy

--- a/TALENT/model/methods/tabpfn_real.py
+++ b/TALENT/model/methods/tabpfn_real.py
@@ -1,4 +1,5 @@
 from TALENT.model.methods.tabpfn_v2 import TabPFNMethod
+from TALENT.model.method_registry import resolve_bundled_path
 
 
 class TabPFNRealMethod(TabPFNMethod):
@@ -7,8 +8,11 @@ class TabPFNRealMethod(TabPFNMethod):
             raise ValueError("TabPFN-Real only supports classification tasks.")
         else:
             from TALENT.model.models.tabpfn_v2 import TabPFNClassifier
+            model_path = resolve_bundled_path(
+                "model/models/models_tabpfn/tabpfn-v2-classifier-finetuned-zk73skhh.ckpt"
+            ) or "auto"
             self.model = TabPFNClassifier(
-                model_path = "./TALENT/model/models/models_tabpfn/tabpfn-v2-classifier-finetuned-zk73skhh.ckpt",
+                model_path = model_path,
                 device = self.args.device,
                 random_state = self.args.seed,
                 n_estimators = 4,

--- a/TALENT/model/methods/tabpfn_v2.py
+++ b/TALENT/model/methods/tabpfn_v2.py
@@ -42,10 +42,16 @@ class TabPFNMethod(Method):
 
 
     def construct_model(self, model_config = None,cat_indices=[]):
+        from TALENT.model.method_registry import resolve_bundled_path
         if self.is_regression:
             from TALENT.model.models.tabpfn_v2 import TabPFNRegressor
+            # Use bundled checkpoint if present; otherwise fall back to the
+            # TabPFN library's auto-download (model_path="auto").
+            model_path = resolve_bundled_path(
+                "model/models/models_tabpfn/tabpfn-v2-regressor.ckpt"
+            ) or "auto"
             self.model = TabPFNRegressor(
-                model_path = "./TALENT/model/models/models_tabpfn/tabpfn-v2-regressor.ckpt",
+                model_path = model_path,
                 device = self.args.device,
                 random_state = self.args.seed,
                 n_estimators = 8,
@@ -54,8 +60,11 @@ class TabPFNMethod(Method):
             )
         else:
             from TALENT.model.models.tabpfn_v2 import TabPFNClassifier
+            model_path = resolve_bundled_path(
+                "model/models/models_tabpfn/tabpfn-v2-classifier.ckpt"
+            ) or "auto"
             self.model = TabPFNClassifier(
-                model_path = "./TALENT/model/models/models_tabpfn/tabpfn-v2-classifier.ckpt",
+                model_path = model_path,
                 device = self.args.device,
                 random_state = self.args.seed,
                 n_estimators = 4,

--- a/TALENT/model/methods/tabpfn_v2_5.py
+++ b/TALENT/model/methods/tabpfn_v2_5.py
@@ -1,0 +1,195 @@
+"""TabPFN v2.5 method.
+
+TabPFN v2.5 (PriorLabs, November 2025) is the intermediate release between
+v2 (Nature 2025) and v3 (2026). It scales in-context learning to ~50 000
+rows × 2 000 features and is a drop-in replacement for v2 with better
+accuracy and speed.
+
+Like v3, v2.5 is distributed through the upstream `tabpfn>=8.0.0`
+package; we pin the version via ``ModelVersion.V2_5`` when the version-
+aware ``create_default_for_version`` classmethod is available, with a
+plain constructor fallback otherwise.
+
+Setup:
+    pip install -U 'tabpfn>=8.0.0'
+"""
+
+from TALENT.model.methods.base import Method
+import torch
+import numpy as np
+import torch.nn.functional as F
+
+from TALENT.model.lib.data import (
+    Dataset,
+    data_nan_process,
+    data_enc_process,
+    data_label_process,
+)
+import time
+
+
+class TabPFNv2_5Method(Method):
+    """TabPFN v2.5 (in-context tabular foundation model).
+
+    Uses the official `tabpfn>=8.0.0` package. Pins the model version to
+    v2.5 via ``ModelVersion.V2_5`` when available; falls back to whatever
+    the installed package's default model version is otherwise.
+    """
+
+    def __init__(self, args, is_regression):
+        super().__init__(args, is_regression)
+        assert args.normalization == 'none'
+        assert args.cat_policy == 'indices'
+        assert args.num_policy == 'none'
+        assert args.tune is not True
+
+    def data_format(self, is_train=True, N=None, C=None, y=None):
+        if is_train:
+            self.N, self.C, self.num_new_value, self.imputer, self.cat_new_value = data_nan_process(
+                self.N, self.C, self.args.num_nan_policy, self.args.cat_nan_policy
+            )
+            self.y, self.y_info, self.label_encoder = data_label_process(self.y, self.is_regression)
+            self.N, self.C, self.ord_encoder, self.mode_values, self.cat_encoder = data_enc_process(
+                self.N, self.C, self.args.cat_policy
+            )
+            self.criterion = F.cross_entropy if not self.is_regression else F.mse_loss
+        else:
+            N_test, C_test, _, _, _ = data_nan_process(
+                N, C, self.args.num_nan_policy, self.args.cat_nan_policy,
+                self.num_new_value, self.imputer, self.cat_new_value
+            )
+            N_test, C_test, _, _, _ = data_enc_process(
+                N_test, C_test, self.args.cat_policy, None,
+                self.ord_encoder, self.mode_values, self.cat_encoder
+            )
+            y_test, _, _ = data_label_process(y, self.is_regression, self.y_info, self.label_encoder)
+            if N_test is not None and C_test is not None:
+                self.N_test, self.C_test = N_test['test'], C_test['test']
+            elif N_test is None and C_test is not None:
+                self.N_test, self.C_test = None, C_test['test']
+            else:
+                self.N_test, self.C_test = N_test['test'], None
+            self.y_test = y_test['test']
+
+    def construct_model(self, model_config=None, cat_indices=None):
+        cat_indices = cat_indices or []
+        try:
+            from tabpfn import TabPFNClassifier, TabPFNRegressor
+        except ImportError as e:
+            raise ImportError(
+                "TabPFN v2.5 requires the `tabpfn` package (>=8.0.0). "
+                "Install it via: pip install -U 'tabpfn>=8.0.0'."
+            ) from e
+
+        general = self.args.config.get('general', {}) or {}
+        n_est_default = 8 if self.is_regression else 4
+
+        kwargs = dict(
+            device=self.args.device,
+            random_state=self.args.seed,
+            ignore_pretraining_limits=general.get('ignore_pretraining_limits', True),
+            categorical_features_indices=cat_indices,
+            n_estimators=general.get('n_estimators', n_est_default),
+        )
+        # Optional user-supplied knobs forwarded if present.
+        for k in ('softmax_temperature', 'memory_saving_mode', 'fit_mode',
+                  'inference_precision', 'model_path'):
+            if k in general:
+                kwargs[k] = general[k]
+
+        model_cls = TabPFNRegressor if self.is_regression else TabPFNClassifier
+
+        # Prefer the version-pinning classmethod when available so we are
+        # explicit about wanting v2.5 even on systems that default to v3.
+        try:
+            from tabpfn.constants import ModelVersion
+            version = getattr(ModelVersion, 'V2_5', None)
+            if version is not None and hasattr(model_cls, 'create_default_for_version'):
+                self.model = model_cls.create_default_for_version(version, **kwargs)
+                return
+        except ImportError:
+            pass
+
+        # Fallback path -- use the installed package's default model version.
+        self.model = model_cls(**kwargs)
+
+    def fit(self, data, info, train=True, config=None):
+        N, C, y = data
+        self.D = Dataset(N, C, y, info)
+        self.N, self.C, self.y = self.D.N, self.D.C, self.D.y
+        self.is_binclass, self.is_multiclass, self.is_regression = (
+            self.D.is_binclass, self.D.is_multiclass, self.D.is_regression
+        )
+        self.data_format(is_train=True)
+
+        sampled_Y = self.y['train']
+        cat_indices = []
+        if self.N is not None and self.C is not None:
+            sampled_X = np.concatenate((self.N['train'], self.C['train']), axis=1)
+            n_num = self.N['train'].shape[1]
+            cat_indices = list(range(n_num, n_num + self.C['train'].shape[1]))
+        elif self.N is None and self.C is not None:
+            sampled_X = self.C['train']
+            cat_indices = list(range(self.C['train'].shape[1]))
+        else:
+            sampled_X = self.N['train']
+
+        # Optional sample_size cap (v2.5 supports up to ~50k natively).
+        general = self.args.config.get('general', {}) or {}
+        sample_size = general.get('sample_size', None)
+        if sample_size is not None and sampled_X.shape[0] > sample_size:
+            if not self.is_regression:
+                from sklearn.model_selection import train_test_split
+                sampled_X, _, sampled_Y, _ = train_test_split(
+                    sampled_X, sampled_Y,
+                    train_size=sample_size,
+                    stratify=sampled_Y,
+                    random_state=self.args.seed,
+                )
+            else:
+                rng = np.random.RandomState(self.args.seed)
+                idx = rng.choice(sampled_X.shape[0], size=sample_size, replace=False)
+                sampled_X = sampled_X[idx]
+                sampled_Y = sampled_Y[idx]
+
+        self.sampled_X = sampled_X
+        self.sampled_Y = sampled_Y
+        self.construct_model(cat_indices=cat_indices)
+
+        tic = time.time()
+        self.model.fit(sampled_X, sampled_Y)
+        self.fit_time = time.time() - tic
+
+    def predict(self, data, info, model_name):
+        N, C, y = data
+        self.data_format(False, N, C, y)
+        if self.N_test is not None and self.C_test is not None:
+            Test_X = np.concatenate((self.N_test, self.C_test), axis=1)
+        elif self.N_test is None and self.C_test is not None:
+            Test_X = self.C_test
+        else:
+            Test_X = self.N_test
+
+        tic = time.time()
+        if self.is_regression:
+            test_logit = self.model.predict(Test_X)
+        else:
+            test_logit = self.model.predict_proba(Test_X)
+        self.predict_time = time.time() - tic
+
+        test_label = self.y_test
+        if self.is_regression:
+            t_pred = torch.tensor(test_logit, dtype=torch.float32).reshape(-1)
+            t_lab = torch.tensor(test_label, dtype=torch.float32).reshape(-1)
+            vl = self.criterion(t_pred, t_lab).item()
+        else:
+            vl = self.criterion(torch.tensor(test_logit), torch.tensor(test_label)).item()
+        vres, metric_name = self.metric(test_logit, test_label, self.y_info)
+
+        # Denormalize regression predictions for the returned value
+        if self.is_regression and self.y_info.get('policy') == 'mean_std':
+            test_logit = test_logit * self.y_info['std'] + self.y_info['mean']
+        print('Test: loss={:.4f}'.format(vl))
+        for name, res in zip(metric_name, vres):
+            print('[{}]={:.4f}'.format(name, res))
+        return vl, vres, metric_name, test_logit

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Welcome to **TALENT**, a benchmark with a comprehensive machine learning toolbox
 
 ## 📰 What's New
 
+- [2026-06]🌟 Evaluation improvements: **calibration metrics** (Brier, ECE) are now reported by default for every classifier, **decision thresholds** are tuned on the validation set for binary classification (used for Accuracy/F1/Precision/Recall; threshold-independent metrics like AUC/LogLoss/Brier/ECE are unaffected), and `RunResult` exposes a uniform `predict_proba`/`predict_labels` interface regardless of whether the underlying method natively returns logits or probabilities. Bundled checkpoints are now resolved via `importlib.resources` so methods work from any working directory.
 - [2026-05]🌟 Add [TabPFN v3](https://github.com/PriorLabs/TabPFN) (PriorLabs 2026) and [TabICL v2](https://github.com/soda-inria/tabicl) (ICML 2026, regression support added).
 - [2026-03]🌟 We have updated the TALENT-extension datasets and results. [Link](https://box.nju.edu.cn/d/b7b23a19ee054aaba7b6/?p=%2F&mode=list)
 - [2025-11]🌟 Add [RFM](https://www.science.org/doi/10.1126/science.adi5639) (Science).

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Welcome to **TALENT**, a benchmark with a comprehensive machine learning toolbox
 
 ## 📰 What's New
 
+- [2026-06]🌟 Add **[TabPFN v2.5](https://arxiv.org/abs/2511.08667)** (PriorLabs, Nov 2025) and **[TabDPT](https://github.com/layer6ai-labs/TabDPT-inference)** (Layer 6 AI, ICL + retrieval). TALENT now ships the full TabPFN family (v1, v2, v2.5, v3) plus TabDPT alongside the other tabular foundation models.
 - [2026-06]🌟 Evaluation improvements: **calibration metrics** (Brier, ECE) are now reported by default for every classifier, **decision thresholds** are tuned on the validation set for binary classification (used for Accuracy/F1/Precision/Recall; threshold-independent metrics like AUC/LogLoss/Brier/ECE are unaffected), and `RunResult` exposes a uniform `predict_proba`/`predict_labels` interface regardless of whether the underlying method natively returns logits or probabilities. Bundled checkpoints are now resolved via `importlib.resources` so methods work from any working directory.
 - [2026-05]🌟 Add [TabPFN v3](https://github.com/PriorLabs/TabPFN) (PriorLabs 2026) and [TabICL v2](https://github.com/soda-inria/tabicl) (ICML 2026, regression support added).
 - [2026-03]🌟 We have updated the TALENT-extension datasets and results. [Link](https://box.nju.edu.cn/d/b7b23a19ee054aaba7b6/?p=%2F&mode=list)
@@ -156,6 +157,8 @@ TALENT integrates an extensive array of 30+ deep learning architectures for tabu
 40. **[xRFM](https://arxiv.org/abs/2508.10053)**: A tabular model that combines RFMs with an adaptive tree structure, enabling it to learn features local to data subsets and scale log-linearly with the number of samples.
 41. **[TabPFN v3](https://github.com/PriorLabs/TabPFN)**: TabPFN v3 (PriorLabs 2026), with native context up to ~1M rows × 200 features, 160-class support, and an optional thinking mode. Requires `pip install -U 'tabpfn>=8.0.0'`.
 42. **[TabICL v2](https://github.com/soda-inria/tabicl)**: TabICL v2 (ICML 2026), now supporting both classification and regression (via `TabICLRegressor`), with native quantile regression. Requires `pip install -U 'tabicl>=2.0.0'`.
+43. **[TabPFN v2.5](https://arxiv.org/abs/2511.08667)**: TabPFN v2.5 (PriorLabs, Nov 2025), the intermediate release between v2 and v3. Scales in-context learning to ~50k rows × 2k features. Requires `pip install -U 'tabpfn>=8.0.0'`.
+44. **[TabDPT](https://github.com/layer6ai-labs/TabDPT-inference)**: A tabular foundation model from Layer 6 AI that combines in-context learning with retrieval and self-supervised pre-training on real data, removing fixed context-size limits. Requires `pip install -U tabdpt`.
 
 
 🔧 If you want to check the **default hyperparameters and hyperparameter search spaces** of all methods, please visit:  
@@ -386,6 +389,7 @@ We thank the following repos for providing helpful components/functions in our w
 - [TabAutoPNPNet](https://github.com/matteo-rizzo/periodic-tabular-dl)
 - [LimiX](https://github.com/limix-ldm/LimiX)
 - [xRFM](https://github.com/dmbeaglehole/xRFM)
+- [TabDPT](https://github.com/layer6ai-labs/TabDPT-inference)
 
 ## 🤗 Contact
 

--- a/test/train_model_classical.py
+++ b/test/train_model_classical.py
@@ -1,28 +1,43 @@
 from tqdm import tqdm
 from TALENT.model.utils import (
-    get_classical_args,tune_hyper_parameters,
-    show_results_classical,get_method,set_seeds
+    get_classical_args, tune_hyper_parameters,
+    show_results_classical, get_method, set_seeds,
 )
-from TALENT.model.lib.data import (
-    get_dataset
-)
+from TALENT.model.lib.data import get_dataset
+from TALENT.model.lib.evaluation import evaluate
+from TALENT.model.method_registry import get_method_spec
 
 
 if __name__ == '__main__':
     results_list, time_list = [], []
-    args,default_para,opt_space = get_classical_args()
-    train_val_data,test_data,info = get_dataset(args.dataset,args.dataset_path)
+    args, default_para, opt_space = get_classical_args()
+    train_val_data, test_data, info = get_dataset(args.dataset, args.dataset_path)
     if args.tune:
-        args = tune_hyper_parameters(args,opt_space,train_val_data,info)
-    
+        args = tune_hyper_parameters(args, opt_space, train_val_data, info)
+
+    spec = get_method_spec(args.model_type)
+
     ## Training Stage over different random seeds
     for seed in tqdm(range(args.seed_num)):
-        args.seed = seed    # update seed  
+        args.seed = seed    # update seed
         set_seeds(args.seed)
         method = get_method(args.model_type)(args, info['task_type'] == 'regression')
-        time_cost = method.fit(train_val_data, info,train=True)    
-        vres, metric_name, predict_logits = method.predict(test_data, info, model_name=args.evaluate_option)
+        time_cost = method.fit(train_val_data, info, train=True)
+        # Centralized evaluator: predict_proba standardization + (for
+        # binary classification) decision threshold tuning on the
+        # validation set, applied to Accuracy/F1/Precision/Recall.
+        eval_result = evaluate(
+            method,
+            train_val_data,
+            test_data,
+            info,
+            model_name=args.evaluate_option,
+            output_type=spec.output_type,
+            tune_threshold=True,
+        )
+        vres = eval_result["metrics"]
+        metric_name = eval_result["metric_names"]
 
         results_list.append(vres)
         time_list.append(time_cost)
-    show_results_classical(args,info, metric_name,results_list,time_list)
+    show_results_classical(args, info, metric_name, results_list, time_list)

--- a/test/train_model_deep.py
+++ b/test/train_model_deep.py
@@ -4,11 +4,11 @@ from TALENT.model.utils import (
     show_results,
     tune_hyper_parameters,
     get_method,
-    set_seeds
+    set_seeds,
 )
-from TALENT.model.lib.data import (
-    get_dataset
-)
+from TALENT.model.lib.data import get_dataset
+from TALENT.model.lib.evaluation import evaluate
+from TALENT.model.method_registry import get_method_spec
 
 
 if __name__ == '__main__':
@@ -17,14 +17,30 @@ if __name__ == '__main__':
     train_val_data, test_data, info = get_dataset(args.dataset, args.dataset_path)
     if args.tune:
         args = tune_hyper_parameters(args, opt_space, train_val_data, info)
-    
+
+    spec = get_method_spec(args.model_type)
+
     ## Training Stage over different random seeds
     for seed in tqdm(range(args.seed_num)):
-        args.seed = seed    # update seed  
+        args.seed = seed    # update seed
         set_seeds(args.seed)
         method = get_method(args.model_type)(args, info['task_type'] == 'regression')
-        method.fit(train_val_data, info)    
-        vl, vres, metric_name, predict_logits = method.predict(test_data, info, model_name=args.evaluate_option)
+        method.fit(train_val_data, info)
+        # The evaluator handles predict_proba standardization and, for
+        # binary classification, tunes the decision threshold on the
+        # validation set (used for Accuracy/F1/Precision/Recall).
+        eval_result = evaluate(
+            method,
+            train_val_data,
+            test_data,
+            info,
+            model_name=args.evaluate_option,
+            output_type=spec.output_type,
+            tune_threshold=True,
+        )
+        vl = eval_result["loss"]
+        vres = eval_result["metrics"]
+        metric_name = eval_result["metric_names"]
 
         loss_list.append(vl)
         results_list.append(vres)


### PR DESCRIPTION
## Summary

- **Calibration metrics** — `Brier` and `ECE` (Guo et al. 2017) now reported by default for every classifier, appended to the existing metric tuple (positional indices for old metrics unchanged).
- **Threshold tuning on validation** — for binary classification, the decision threshold is now optimized on the val split (F1 by default; configurable) and applied to Accuracy / F1 / Avg_Precision / Avg_Recall. Threshold-independent metrics (LogLoss, AUC, Brier, ECE) are unaffected. Both CLI and `TALENT.run()` use the same code path.
- **`predict_proba` standardization** — `RunResult` now exposes a uniform `(N, K)` probability array regardless of whether the method natively outputs logits or probabilities, plus `predict_labels` (using the tuned threshold) and the `threshold` itself.
- **Bundled checkpoint paths fixed** — `tabpfn_v2`, `tabpfn_real`, `tabicl`, `limix`, and `mitra` previously used hardcoded `./TALENT/...` relative paths that only worked from the repo root. They now resolve via `importlib.resources` so the package works from any working directory.

## Files

- New: `model/lib/calibration.py`, `model/lib/threshold.py`, `model/lib/evaluation.py`
- Modified: `methods/base.py`, `classical_methods/base.py` (added `threshold=None` kwarg + Brier/ECE), `xrfm.py` (now inherits unified base — was missing LogLoss/AUC), `protogate.py` and `lr.py` (signature compat), 5 method files (path fix), `api.py` (uses `evaluate()`, new `RunResult` fields), `train_model_deep.py` and `train_model_classical.py` (use `evaluate()`)

## Compatibility

- Old positional metric indices preserved (new metrics appended at end).
- Bundled paths fall back to the legacy `./TALENT/...` string if the resource is missing, so behavior from the repo root is unchanged.
- `protogate` correctly re-classified as `OutputType.CLASS_LABELS` in the registry (it returns hard labels, not probabilities).

Threshold tuning uses the validation split that TALENT already requires for every dataset — no dataset contract change.