### PR TITLE
Make the method registry the single source of truth for foundation-mo…

### DIFF
--- a/TALENT/configs/default/tabdpt.json
+++ b/TALENT/configs/default/tabdpt.json
@@ -3,7 +3,6 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 100000,
             "n_ensembles": 8,
             "context_size": 2048,
             "temperature": 0.8,

--- a/TALENT/configs/default/tabicl_v2.json
+++ b/TALENT/configs/default/tabicl_v2.json
@@ -3,7 +3,6 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 60000,
             "n_estimators": 32,
             "batch_size": 8,
             "use_amp": true,

--- a/TALENT/configs/default/tabpfn.json
+++ b/TALENT/configs/default/tabpfn.json
@@ -2,8 +2,6 @@
     "tabpfn": {
         "model": {},
         "training": {},
-        "general": {
-            "sample_size": 3000
-        }
+        "general": {}
     }
 }

--- a/TALENT/configs/default/tabpfn_real.json
+++ b/TALENT/configs/default/tabpfn_real.json
@@ -2,8 +2,6 @@
     "tabpfn_real": {
         "model": {},
         "training": {},
-        "general": {
-            "sample_size": 10000
-        }
+        "general": {}
     }
 }

--- a/TALENT/configs/default/tabpfn_v2.json
+++ b/TALENT/configs/default/tabpfn_v2.json
@@ -2,8 +2,6 @@
     "tabpfn_v2": {
         "model": {},
         "training": {},
-        "general": {
-            "sample_size": 10000
-        }
+        "general": {}
     }
 }

--- a/TALENT/configs/default/tabpfn_v2_5.json
+++ b/TALENT/configs/default/tabpfn_v2_5.json
@@ -3,7 +3,6 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 50000,
             "ignore_pretraining_limits": true,
             "n_estimators": 8
         }

--- a/TALENT/configs/default/tabpfn_v3.json
+++ b/TALENT/configs/default/tabpfn_v3.json
@@ -3,7 +3,6 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 1000000,
             "ignore_pretraining_limits": true,
             "n_estimators": 32
         }

--- a/TALENT/configs/opt_space/tabdpt.json
+++ b/TALENT/configs/opt_space/tabdpt.json
@@ -3,7 +3,6 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 100000,
             "n_ensembles": 8,
             "context_size": 2048,
             "temperature": 0.8,

--- a/TALENT/configs/opt_space/tabicl_v2.json
+++ b/TALENT/configs/opt_space/tabicl_v2.json
@@ -3,7 +3,6 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 60000,
             "n_estimators": 32,
             "batch_size": 8,
             "use_amp": true,

--- a/TALENT/configs/opt_space/tabpfn_real.json
+++ b/TALENT/configs/opt_space/tabpfn_real.json
@@ -2,8 +2,6 @@
     "tabpfn_real": {
         "model": {},
         "training": {},
-        "general": {
-            "sample_size": 10000
-        }
+        "general": {}
     }
 }

--- a/TALENT/configs/opt_space/tabpfn_v2.json
+++ b/TALENT/configs/opt_space/tabpfn_v2.json
@@ -2,8 +2,6 @@
     "tabpfn_v2": {
         "model": {},
         "training": {},
-        "general": {
-            "sample_size": 10000
-        }
+        "general": {}
     }
 }

--- a/TALENT/configs/opt_space/tabpfn_v2_5.json
+++ b/TALENT/configs/opt_space/tabpfn_v2_5.json
@@ -3,7 +3,6 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 50000,
             "ignore_pretraining_limits": true,
             "n_estimators": 8
         }

--- a/TALENT/configs/opt_space/tabpfn_v3.json
+++ b/TALENT/configs/opt_space/tabpfn_v3.json
@@ -3,9 +3,8 @@
         "model": {},
         "training": {},
         "general": {
-            "sample_size": 50000,
             "ignore_pretraining_limits": true,
-            "n_estimators": 4
+            "n_estimators": 32
         }
     }
 }

--- a/TALENT/model/classical_methods/base.py
+++ b/TALENT/model/classical_methods/base.py
@@ -5,7 +5,8 @@ from sklearn.preprocessing import label_binarize
 
 from TALENT.model.utils import (
     set_seeds,
-    get_device
+    get_device,
+    check_softmax
 )
 # from sklearn.externals import joblib
 from TALENT.model.lib.data import (
@@ -17,14 +18,7 @@ from TALENT.model.lib.data import (
     data_label_process,
 )
 
-def check_softmax(logits):
-    # Check if any values are outside the [0, 1] range and Ensure they sum to 1
-    if np.any((logits < 0) | (logits > 1)) or (not np.allclose(logits.sum(axis=-1), 1, atol=1e-5)):
-        exps = np.exp(logits - np.max(logits, axis=1, keepdims=True))  # stabilize by subtracting max
-        return exps / np.sum(exps, axis=1, keepdims=True)
-    else:
-        return logits
-    
+
 class classical_methods(object, metaclass=abc.ABCMeta):
     def __init__(self, args, is_regression):
         self.args = args

--- a/TALENT/model/classical_methods/base.py
+++ b/TALENT/model/classical_methods/base.py
@@ -111,7 +111,7 @@ class classical_methods(object, metaclass=abc.ABCMeta):
                 hard_preds = predictions.argmax(axis=-1)
             accuracy = skm.accuracy_score(labels, hard_preds)
             avg_recall = skm.balanced_accuracy_score(labels, hard_preds)
-            avg_precision = skm.precision_score(labels, hard_preds, average='macro')
+            avg_precision = skm.precision_score(labels, hard_preds, average='macro', zero_division=0)
             f1_score = skm.f1_score(labels, hard_preds, average='binary')
             log_loss = skm.log_loss(labels, predictions, labels=y_info['classes'])
             auc = skm.roc_auc_score(labels, predictions[:, 1], labels=y_info['classes']) if len(np.unique(labels)) == 2 else float("nan")
@@ -127,7 +127,7 @@ class classical_methods(object, metaclass=abc.ABCMeta):
             hard_preds = predictions.argmax(axis=-1)
             accuracy = skm.accuracy_score(labels, hard_preds)
             avg_recall = skm.balanced_accuracy_score(labels, hard_preds)
-            avg_precision = skm.precision_score(labels, hard_preds, average='macro')
+            avg_precision = skm.precision_score(labels, hard_preds, average='macro', zero_division=0)
             f1_score = skm.f1_score(labels, hard_preds, average='macro')
             log_loss = skm.log_loss(labels, predictions, labels=y_info['classes'])
 

--- a/TALENT/model/lib/limix/model/transformer.py
+++ b/TALENT/model/lib/limix/model/transformer.py
@@ -252,7 +252,7 @@ class FeaturesTransformer(nn.Module):
         return data
     
     def add_embeddings(self, x:torch.Tensor):
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast("cuda", enabled=False):
             embs = torch.randn(
                 (x.shape[2], x.shape[3] // 4),
                 device=x.device,

--- a/TALENT/model/lib/tabpfn/layer.py
+++ b/TALENT/model/lib/tabpfn/layer.py
@@ -92,7 +92,7 @@ class TransformerEncoderLayer(Module):
             eval_tokens_src = src_[num_global_tokens+num_train_tokens:]
 
 
-            attn = partial(checkpoint, self.self_attn) if self.recompute_attn else self.self_attn
+            attn = partial(checkpoint, self.self_attn, use_reentrant=False) if self.recompute_attn else self.self_attn
 
             global_tokens_src2 = attn(global_tokens_src, global_and_train_tokens_src, global_and_train_tokens_src, None, True, global_src_mask)[0]
             train_tokens_src2 = attn(train_tokens_src, global_tokens_src, global_tokens_src, None, True, trainset_src_mask)[0]
@@ -109,7 +109,7 @@ class TransformerEncoderLayer(Module):
             src2 = torch.cat([src_left, src_right], dim=0)
         else:
             if self.recompute_attn:
-                src2 = checkpoint(self.self_attn, src_, src_, src_, src_key_padding_mask, True, src_mask)[0]
+                src2 = checkpoint(self.self_attn, src_, src_, src_, src_key_padding_mask, True, src_mask, use_reentrant=False)[0]
             else:
                 src2 = self.self_attn(src_, src_, src_, attn_mask=src_mask,
                                       key_padding_mask=src_key_padding_mask)[0]

--- a/TALENT/model/lib/tabpfn/utils.py
+++ b/TALENT/model/lib/tabpfn/utils.py
@@ -452,10 +452,10 @@ def transformer_predict(model, eval_xs, eval_ys, eval_position,
             warnings.filterwarnings("ignore",
                                     message="torch.cuda.amp.autocast only affects CUDA ops, but CUDA is not available.  Disabling.")
             if device == 'cpu':
-                output_batch = checkpoint(predict, batch_input, batch_label, style_, softmax_temperature_, True)
+                output_batch = checkpoint(predict, batch_input, batch_label, style_, softmax_temperature_, True, use_reentrant=False)
             else:
-                with torch.cuda.amp.autocast(enabled=fp16_inference):
-                    output_batch = checkpoint(predict, batch_input, batch_label, style_, softmax_temperature_, True)
+                with torch.amp.autocast("cuda", enabled=fp16_inference):
+                    output_batch = checkpoint(predict, batch_input, batch_label, style_, softmax_temperature_, True, use_reentrant=False)
         outputs += [output_batch]
     #print('MODEL INFERENCE TIME ('+str(batch_input.device)+' vs '+device+', '+str(fp16_inference)+')', str(time.time()-start))
 

--- a/TALENT/model/methods/base.py
+++ b/TALENT/model/methods/base.py
@@ -391,7 +391,7 @@ class Method(object, metaclass=abc.ABCMeta):
                 hard_preds = predictions.argmax(axis=-1)
             accuracy = skm.accuracy_score(labels, hard_preds)
             avg_recall = skm.balanced_accuracy_score(labels, hard_preds)
-            avg_precision = skm.precision_score(labels, hard_preds, average='macro')
+            avg_precision = skm.precision_score(labels, hard_preds, average='macro', zero_division=0)
             f1_score = skm.f1_score(labels, hard_preds, average='binary')
             log_loss = skm.log_loss(labels, predictions, labels=y_info['classes'])
             auc = skm.roc_auc_score(labels, predictions[:, 1], labels=y_info['classes']) if len(np.unique(labels)) == 2 else float("nan")
@@ -409,7 +409,7 @@ class Method(object, metaclass=abc.ABCMeta):
             hard_preds = predictions.argmax(axis=-1)
             accuracy = skm.accuracy_score(labels, hard_preds)
             avg_recall = skm.balanced_accuracy_score(labels, hard_preds)
-            avg_precision = skm.precision_score(labels, hard_preds, average='macro')
+            avg_precision = skm.precision_score(labels, hard_preds, average='macro', zero_division=0)
             f1_score = skm.f1_score(labels, hard_preds, average='macro')
             log_loss = skm.log_loss(labels, predictions, labels=y_info['classes'])
 

--- a/TALENT/model/methods/base.py
+++ b/TALENT/model/methods/base.py
@@ -11,7 +11,8 @@ from TALENT.model.utils import (
     Timer,
     Averager,
     set_seeds,
-    get_device
+    get_device,
+    check_softmax
 )
 
 from TALENT.model.lib.data import (
@@ -24,21 +25,6 @@ from TALENT.model.lib.data import (
     data_loader_process,
     get_categories
 )
-
-
-def check_softmax(logits):
-    """
-    Check if the logits are already probabilities, and if not, convert them to probabilities.
-    
-    :param logits: np.ndarray of shape (N, C) with logits
-    :return: np.ndarray of shape (N, C) with probabilities
-    """
-    # Check if any values are outside the [0, 1] range and Ensure they sum to 1
-    if np.any((logits < 0) | (logits > 1)) or (not np.allclose(logits.sum(axis=-1), 1, atol=1e-5)):
-        exps = np.exp(logits - np.max(logits, axis=1, keepdims=True))  # stabilize by subtracting max
-        return exps / np.sum(exps, axis=1, keepdims=True)
-    else:
-        return logits
 
 
 class Method(object, metaclass=abc.ABCMeta):
@@ -91,6 +77,54 @@ class Method(object, metaclass=abc.ABCMeta):
             self.trlog['best_res'] = 1e10
         else:
             self.trlog['best_res'] = 0
+
+
+    def resolve_sample_size(self):
+        """
+        Resolve the effective training-row cap for this method.
+
+        An explicit ``config['general']['sample_size']`` takes precedence as a
+        per-run override; otherwise the method's ``train_row_limit`` from the
+        method registry applies (the single source of truth for row limits).
+        Returns None when neither is set (no cap).
+        """
+        general = self.args.config.get('general', {}) or {}
+        sample_size = general.get('sample_size')
+        if sample_size is not None:
+            return sample_size
+        from TALENT.model.method_registry import get_method_spec
+        try:
+            return get_method_spec(self.args.model_type).train_row_limit
+        except (KeyError, AttributeError):
+            return None
+
+
+    def subsample_train_rows(self, X, y):
+        """
+        Cap the training rows at ``resolve_sample_size()`` rows.
+
+        Classification subsamples stratified by label to keep class
+        proportions; regression takes a uniform random subset. Both are
+        seeded with ``args.seed`` for reproducibility. Returns (X, y)
+        unchanged when no cap applies.
+        """
+        sample_size = self.resolve_sample_size()
+        if sample_size is None or X.shape[0] <= sample_size:
+            return X, y
+        if not self.is_regression:
+            from sklearn.model_selection import train_test_split
+            X, _, y, _ = train_test_split(
+                X, y,
+                train_size=sample_size,
+                stratify=y,
+                random_state=self.args.seed,
+            )
+        else:
+            rng = np.random.RandomState(self.args.seed)
+            idx = rng.choice(X.shape[0], size=sample_size, replace=False)
+            X = X[idx]
+            y = y[idx]
+        return X, y
 
 
     def data_format(self, is_train = True, N = None, C = None, y = None):

--- a/TALENT/model/methods/excelformer.py
+++ b/TALENT/model/methods/excelformer.py
@@ -24,15 +24,8 @@ from TALENT.model.lib.data import (
     get_categories
 )
 from TALENT.model.methods.base import Method
+from TALENT.model.utils import check_softmax
 
-def check_softmax(logits):
-    # Check if any values are outside the [0, 1] range and Ensure they sum to 1
-    if np.any((logits < 0) | (logits > 1)) or (not np.allclose(logits.sum(axis=-1), 1, atol=1e-5)):
-        exps = np.exp(logits - np.max(logits, axis=1, keepdims=True))  # stabilize by subtracting max
-        return exps / np.sum(exps, axis=1, keepdims=True)
-    else:
-        return logits
-  
 class ExcelFormerMethod(Method):
     def __init__(self, args, is_regression):
         super().__init__(args, is_regression)

--- a/TALENT/model/methods/grownet.py
+++ b/TALENT/model/methods/grownet.py
@@ -3,7 +3,6 @@ import argparse
 import torch
 from tqdm import tqdm
 import numpy as np
-import torch
 
 from TALENT.model.lib.data import (
     Dataset

--- a/TALENT/model/methods/hyperfast.py
+++ b/TALENT/model/methods/hyperfast.py
@@ -1,7 +1,6 @@
 from TALENT.model.methods.base import Method
 import torch
 import numpy as np
-import torch
 import torch.nn.functional as F
 
 from TALENT.model.lib.data import (

--- a/TALENT/model/methods/limix.py
+++ b/TALENT/model/methods/limix.py
@@ -1,7 +1,6 @@
 from TALENT.model.methods.base import Method
 import torch
 import numpy as np
-import torch
 import torch.nn.functional as F
 
 from TALENT.model.lib.data import (

--- a/TALENT/model/methods/mitra.py
+++ b/TALENT/model/methods/mitra.py
@@ -1,7 +1,6 @@
 from TALENT.model.methods.base import Method
 import torch
 import numpy as np
-import torch
 import torch.nn.functional as F
 
 from TALENT.model.lib.data import (
@@ -74,6 +73,10 @@ class MitraMethod(Method):
         else:
             x_support = self.N['train']
         
+        # Row cap: config['general']['sample_size'] override, else the
+        # registry's train_row_limit (Mitra attends over the full support set).
+        x_support, y_support = self.subsample_train_rows(x_support, y_support)
+
         x_support = x_support.astype(np.float32)
         y_support = y_support.astype(np.float32 if self.is_regression else np.int64)
 
@@ -102,8 +105,9 @@ class MitraMethod(Method):
         n_obs_query = x_query.shape[0]
         n_feat = self.x_support.shape[1]
         
-        max_samples_support = self.args.config['general']['max_samples_support']
-        max_samples_query = self.args.config['general']['max_samples_query']
+        general = self.args.config.get('general', {}) or {}
+        max_samples_support = general.get('max_samples_support', 8192)
+        max_samples_query = general.get('max_samples_query', 1024)
 
         if n_obs_support > max_samples_support:
             idx = torch.randperm(n_obs_support)[:max_samples_support] 

--- a/TALENT/model/methods/ptarl.py
+++ b/TALENT/model/methods/ptarl.py
@@ -1,7 +1,6 @@
 from TALENT.model.methods.base import Method
 import torch
 import numpy as np
-import torch
 import os.path as osp
 from TALENT.model.lib.ptarl.utils import (
     fit_Ptarl,

--- a/TALENT/model/methods/tabcaps.py
+++ b/TALENT/model/methods/tabcaps.py
@@ -1,6 +1,5 @@
 from TALENT.model.methods.base import Method
 import torch
-import torch
 import os.path as osp
 import torch.nn.functional as F
 import numpy as np

--- a/TALENT/model/methods/tabdpt.py
+++ b/TALENT/model/methods/tabdpt.py
@@ -121,25 +121,10 @@ class TabDPTMethod(Method):
         else:
             sampled_X = self.N['train']
 
-        # Optional sample_size cap. TabDPT scales via retrieval so it can
-        # generally handle large train sets, but the cap is exposed for
-        # benchmarking / time-budget consistency with other methods.
-        general = self.args.config.get('general', {}) or {}
-        sample_size = general.get('sample_size', None)
-        if sample_size is not None and sampled_X.shape[0] > sample_size:
-            if not self.is_regression:
-                from sklearn.model_selection import train_test_split
-                sampled_X, _, sampled_Y, _ = train_test_split(
-                    sampled_X, sampled_Y,
-                    train_size=sample_size,
-                    stratify=sampled_Y,
-                    random_state=self.args.seed,
-                )
-            else:
-                rng = np.random.RandomState(self.args.seed)
-                idx = rng.choice(sampled_X.shape[0], size=sample_size, replace=False)
-                sampled_X = sampled_X[idx]
-                sampled_Y = sampled_Y[idx]
+        # Optional row cap. TabDPT scales via retrieval so it has no
+        # registry train_row_limit (unlimited); config['general']['sample_size']
+        # remains available as an explicit per-run override.
+        sampled_X, sampled_Y = self.subsample_train_rows(sampled_X, sampled_Y)
 
         self.sampled_X = sampled_X
         self.sampled_Y = sampled_Y

--- a/TALENT/model/methods/tabicl.py
+++ b/TALENT/model/methods/tabicl.py
@@ -1,7 +1,6 @@
 from TALENT.model.methods.base import Method
 import torch
 import numpy as np
-import torch
 import torch.nn.functional as F
 
 from TALENT.model.lib.data import (
@@ -12,20 +11,8 @@ from TALENT.model.lib.data import (
 )
 import time
 
-def check_softmax(logits):
-    """
-    Check if the logits are already probabilities, and if not, convert them to probabilities.
-    
-    :param logits: np.ndarray of shape (N, C) with logits
-    :return: np.ndarray of shape (N, C) with probabilities
-    """
-    # Check if any values are outside the [0, 1] range and Ensure they sum to 1
-    if np.any((logits < 0) | (logits > 1)) or (not np.allclose(logits.sum(axis=-1), 1, atol=1e-5)):
-        exps = np.exp(logits - np.max(logits, axis=1, keepdims=True))  # stabilize by subtracting max
-        return exps / np.sum(exps, axis=1, keepdims=True)
-    else:
-        return logits
-    
+from TALENT.model.utils import check_softmax
+
 class TabICLMethod(Method):
     def __init__(self, args, is_regression):
         super().__init__(args, is_regression)
@@ -58,7 +45,7 @@ class TabICLMethod(Method):
                 self.N_test,self.C_test = N_test['test'],None
             self.y_test = y_test['test']
 
-    def construct_model(self, model_config = None,cat_indices=[]):
+    def construct_model(self, model_config = None,cat_indices=None):
             from TALENT.model.lib.tabicl.classifier import TabICLClassifier
             from TALENT.model.method_registry import resolve_bundled_path
             # Use bundled checkpoint if present; otherwise the TabICL library
@@ -105,18 +92,10 @@ class TabICLMethod(Method):
         else:
             sampled_X = self.N['train']
 
-        # Optional sample_size cap — TabICL keeps the full train set in-context,
-        # which can OOM on big datasets. Configurable via config['general']['sample_size'].
-        general = self.args.config.get('general', {}) or {}
-        sample_size = general.get('sample_size', None)
-        if sample_size is not None and sampled_X.shape[0] > sample_size:
-            from sklearn.model_selection import train_test_split
-            sampled_X, _, sampled_Y, _ = train_test_split(
-                sampled_X, sampled_Y,
-                train_size=sample_size,
-                stratify=sampled_Y,
-                random_state=self.args.seed,
-            )
+        # Row cap — TabICL keeps the full train set in-context, which can OOM
+        # on big datasets. config['general']['sample_size'] override, else the
+        # registry's train_row_limit.
+        sampled_X, sampled_Y = self.subsample_train_rows(sampled_X, sampled_Y)
         self.sampled_X = sampled_X
         self.sampled_Y = sampled_Y
         self.construct_model(cat_indices=cat_indices)

--- a/TALENT/model/methods/tabicl_v2.py
+++ b/TALENT/model/methods/tabicl_v2.py
@@ -11,13 +11,7 @@ from TALENT.model.lib.data import (
 )
 import time
 
-
-def check_softmax(logits):
-    """Convert raw logits to probabilities if not already in [0, 1] summing to 1."""
-    if np.any((logits < 0) | (logits > 1)) or (not np.allclose(logits.sum(axis=-1), 1, atol=1e-5)):
-        exps = np.exp(logits - np.max(logits, axis=1, keepdims=True))
-        return exps / np.sum(exps, axis=1, keepdims=True)
-    return logits
+from TALENT.model.utils import check_softmax
 
 
 class TabICLv2Method(Method):
@@ -126,23 +120,10 @@ class TabICLv2Method(Method):
         else:
             sampled_X = self.N['train']
 
-        # Optional sample_size cap, since TabICL keeps all training rows in-context.
-        general = self.args.config.get('general', {}) or {}
-        sample_size = general.get('sample_size', None)
-        if sample_size is not None and sampled_X.shape[0] > sample_size:
-            if not self.is_regression:
-                from sklearn.model_selection import train_test_split
-                sampled_X, _, sampled_Y, _ = train_test_split(
-                    sampled_X, sampled_Y,
-                    train_size=sample_size,
-                    stratify=sampled_Y,
-                    random_state=self.args.seed,
-                )
-            else:
-                rng = np.random.RandomState(self.args.seed)
-                idx = rng.choice(sampled_X.shape[0], size=sample_size, replace=False)
-                sampled_X = sampled_X[idx]
-                sampled_Y = sampled_Y[idx]
+        # Row cap, since TabICL keeps all training rows in-context.
+        # config['general']['sample_size'] override, else the registry's
+        # train_row_limit.
+        sampled_X, sampled_Y = self.subsample_train_rows(sampled_X, sampled_Y)
 
         self.sampled_X = sampled_X
         self.sampled_Y = sampled_Y

--- a/TALENT/model/methods/tabm.py
+++ b/TALENT/model/methods/tabm.py
@@ -27,22 +27,8 @@ from TALENT.model.lib.data import (
 def loss_fn(_loss_fn,y_pred, y_true):
         return _loss_fn(y_pred.flatten(0, 1), y_true.repeat_interleave(y_pred.shape[1]))
 
-def check_softmax(logits):
-    """
-    Check if the logits are already probabilities, and if not, convert them to probabilities.
-    
-    :param logits: np.ndarray of shape (N, C) with logits
-    :return: np.ndarray of shape (N, C) with probabilities
-    """
-    # Check if any values are outside the [0, 1] range and Ensure they sum to 1
-    if np.any((logits < 0) | (logits > 1)) or (not np.allclose(logits.sum(axis=-1), 1, atol=1e-5)):
-        exps = np.exp(logits - np.max(logits, axis=1, keepdims=True))  # stabilize by subtracting max
-        return exps / np.sum(exps, axis=1, keepdims=True)
-    else:
-        return logits
-
-
 from TALENT.model.methods.base import Method
+from TALENT.model.utils import check_softmax
 
 class TabMMethod(Method):
     def __init__(self, args, is_regression):

--- a/TALENT/model/methods/tabnet.py
+++ b/TALENT/model/methods/tabnet.py
@@ -1,6 +1,5 @@
 from TALENT.model.methods.base import Method
 import torch
-import torch
 import torch.nn.functional as F
 
 from TALENT.model.lib.data import (

--- a/TALENT/model/methods/tabpfn.py
+++ b/TALENT/model/methods/tabpfn.py
@@ -1,7 +1,6 @@
 from TALENT.model.methods.base import Method
 import torch
 import numpy as np
-import torch
 import torch.nn.functional as F
 
 from TALENT.model.lib.data import (
@@ -63,11 +62,9 @@ class TabPFNMethod(Method):
             sampled_X = self.C['train']
         else:
             sampled_X = self.N['train']
-        sample_size = self.args.config['general']['sample_size']
-        if self.y['train'].shape[0] > sample_size:
-        # sampled_X and sampled_Y contain sample_size samples maintaining class proportions for the training set
-            from sklearn.model_selection import train_test_split
-            sampled_X, _, sampled_Y, _ = train_test_split(sampled_X, sampled_Y, train_size=sample_size, stratify=sampled_Y)
+        # Row cap: config['general']['sample_size'] override, else the
+        # registry's train_row_limit. Stratified to keep class proportions.
+        sampled_X, sampled_Y = self.subsample_train_rows(sampled_X, sampled_Y)
         self.model.fit(sampled_X, sampled_Y, overwrite_warning=True)
         self.fit_time = 0  # general model does not require fitting
     

--- a/TALENT/model/methods/tabpfn_real.py
+++ b/TALENT/model/methods/tabpfn_real.py
@@ -3,7 +3,8 @@ from TALENT.model.method_registry import resolve_bundled_path
 
 
 class TabPFNRealMethod(TabPFNMethod):
-    def construct_model(self, model_config = None,cat_indices=[]):
+    def construct_model(self, model_config = None,cat_indices=None):
+        cat_indices = cat_indices or []
         if self.is_regression:
             raise ValueError("TabPFN-Real only supports classification tasks.")
         else:

--- a/TALENT/model/methods/tabpfn_v2.py
+++ b/TALENT/model/methods/tabpfn_v2.py
@@ -104,6 +104,21 @@ class TabPFNMethod(Method):
         self.fit_time = 0  # general model does not require fitting
 
 
+    # Test rows are scored independently (the in-context set is the training
+    # data), so chunked inference is prediction-identical. Chunking bounds the
+    # feature-attention CUDA kernel batch, which otherwise fails with
+    # "invalid configuration argument" on wide datasets with many test rows.
+    PREDICT_CHUNK_ROWS = 8192
+
+    def _predict_in_chunks(self, predict_fn, X):
+        n_rows = X.shape[0]
+        chunk = self.PREDICT_CHUNK_ROWS
+        if n_rows <= chunk:
+            return predict_fn(X)
+        outputs = [predict_fn(X[start:start + chunk])
+                   for start in range(0, n_rows, chunk)]
+        return np.concatenate(outputs, axis=0)
+
     def predict(self, data, info, model_name):
         N, C, y = data
         self.data_format(False, N, C, y)
@@ -113,12 +128,12 @@ class TabPFNMethod(Method):
             Test_X = self.C_test
         else:
             Test_X = self.N_test
-        
+
         tic = time.time()
         if self.is_regression:
-            test_logit = self.model.predict(Test_X)
+            test_logit = self._predict_in_chunks(self.model.predict, Test_X)
         else:
-            test_logit = self.model.predict_proba(Test_X)
+            test_logit = self._predict_in_chunks(self.model.predict_proba, Test_X)
         self.predict_time = time.time() - tic
         
         test_label = self.y_test

--- a/TALENT/model/methods/tabpfn_v2.py
+++ b/TALENT/model/methods/tabpfn_v2.py
@@ -1,7 +1,6 @@
 from TALENT.model.methods.base import Method
 import torch
 import numpy as np
-import torch
 import torch.nn.functional as F
 
 from TALENT.model.lib.data import (
@@ -41,7 +40,8 @@ class TabPFNMethod(Method):
             self.y_test = y_test['test']
 
 
-    def construct_model(self, model_config = None,cat_indices=[]):
+    def construct_model(self, model_config = None,cat_indices=None):
+        cat_indices = cat_indices or []
         from TALENT.model.method_registry import resolve_bundled_path
         if self.is_regression:
             from TALENT.model.models.tabpfn_v2 import TabPFNRegressor
@@ -91,7 +91,12 @@ class TabPFNMethod(Method):
             cat_indices = [i for i in range(self.C['train'].shape[1])]
         else:
             sampled_X = self.N['train']
-        sample_size = self.args.config['general']['sample_size']
+        # Row cap: config['general']['sample_size'] override, else the
+        # registry's train_row_limit. The TabPFN v2 wrapper subsamples
+        # internally, so the cap is forwarded to model.fit().
+        sample_size = self.resolve_sample_size()
+        if sample_size is None:
+            sample_size = sampled_X.shape[0]
         self.sampled_X = sampled_X
         self.sampled_Y = sampled_Y
         self.construct_model(cat_indices=cat_indices)

--- a/TALENT/model/methods/tabpfn_v2_5.py
+++ b/TALENT/model/methods/tabpfn_v2_5.py
@@ -134,23 +134,9 @@ class TabPFNv2_5Method(Method):
         else:
             sampled_X = self.N['train']
 
-        # Optional sample_size cap (v2.5 supports up to ~50k natively).
-        general = self.args.config.get('general', {}) or {}
-        sample_size = general.get('sample_size', None)
-        if sample_size is not None and sampled_X.shape[0] > sample_size:
-            if not self.is_regression:
-                from sklearn.model_selection import train_test_split
-                sampled_X, _, sampled_Y, _ = train_test_split(
-                    sampled_X, sampled_Y,
-                    train_size=sample_size,
-                    stratify=sampled_Y,
-                    random_state=self.args.seed,
-                )
-            else:
-                rng = np.random.RandomState(self.args.seed)
-                idx = rng.choice(sampled_X.shape[0], size=sample_size, replace=False)
-                sampled_X = sampled_X[idx]
-                sampled_Y = sampled_Y[idx]
+        # Row cap: config['general']['sample_size'] override, else the
+        # registry's train_row_limit (~50k native context for v2.5).
+        sampled_X, sampled_Y = self.subsample_train_rows(sampled_X, sampled_Y)
 
         self.sampled_X = sampled_X
         self.sampled_Y = sampled_Y

--- a/TALENT/model/methods/tabpfn_v3.py
+++ b/TALENT/model/methods/tabpfn_v3.py
@@ -115,23 +115,9 @@ class TabPFNv3Method(Method):
         else:
             sampled_X = self.N['train']
 
-        # Optional sample_size cap, useful when running on very large datasets.
-        general = self.args.config.get('general', {}) or {}
-        sample_size = general.get('sample_size', None)
-        if sample_size is not None and sampled_X.shape[0] > sample_size:
-            if not self.is_regression:
-                from sklearn.model_selection import train_test_split
-                sampled_X, _, sampled_Y, _ = train_test_split(
-                    sampled_X, sampled_Y,
-                    train_size=sample_size,
-                    stratify=sampled_Y,
-                    random_state=self.args.seed,
-                )
-            else:
-                rng = np.random.RandomState(self.args.seed)
-                idx = rng.choice(sampled_X.shape[0], size=sample_size, replace=False)
-                sampled_X = sampled_X[idx]
-                sampled_Y = sampled_Y[idx]
+        # Row cap: config['general']['sample_size'] override, else the
+        # registry's train_row_limit (~1M native context for v3).
+        sampled_X, sampled_Y = self.subsample_train_rows(sampled_X, sampled_Y)
 
         self.sampled_X = sampled_X
         self.sampled_Y = sampled_Y

--- a/TALENT/model/methods/tabptm.py
+++ b/TALENT/model/methods/tabptm.py
@@ -1,7 +1,6 @@
 from TALENT.model.methods.base import Method
 import torch
 import numpy as np
-import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 import time

--- a/TALENT/model/methods/trompt.py
+++ b/TALENT/model/methods/trompt.py
@@ -24,15 +24,8 @@ from TALENT.model.lib.data import (
     get_categories
 )
 from TALENT.model.methods.base import Method
+from TALENT.model.utils import check_softmax
 
-def check_softmax(logits):
-    # Check if any values are outside the [0, 1] range and Ensure they sum to 1
-    if np.any((logits < 0) | (logits > 1)) or (not np.allclose(logits.sum(axis=-1), 1, atol=1e-5)):
-        exps = np.exp(logits - np.max(logits, axis=1, keepdims=True))  # stabilize by subtracting max
-        return exps / np.sum(exps, axis=1, keepdims=True)
-    else:
-        return logits
-    
 class TromptMethod(Method):
     def __init__(self, args, is_regression):
         super().__init__(args, is_regression)

--- a/TALENT/model/utils.py
+++ b/TALENT/model/utils.py
@@ -12,6 +12,21 @@ import os.path as osp
 THIS_PATH = os.path.dirname(__file__)
 
 
+def check_softmax(logits):
+    """
+    Check if the logits are already probabilities, and if not, convert them to probabilities.
+
+    :param logits: np.ndarray of shape (N, C) with logits
+    :return: np.ndarray of shape (N, C) with probabilities
+    """
+    # Check if any values are outside the [0, 1] range and Ensure they sum to 1
+    if np.any((logits < 0) | (logits > 1)) or (not np.allclose(logits.sum(axis=-1), 1, atol=1e-5)):
+        exps = np.exp(logits - np.max(logits, axis=1, keepdims=True))  # stabilize by subtracting max
+        return exps / np.sum(exps, axis=1, keepdims=True)
+    else:
+        return logits
+
+
 def mkdir(path):
     """
     Create a directory if it does not exist.

--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,8 @@ for s in TALENT.list_methods(
 
 Both the CLI scripts and the Python API are backed by the same `MethodSpec` registry, so adding a new method requires only a single registry entry (see `TALENT/model/method_registry.py`).
 
+The registry is also the single source of truth for foundation-model training-row caps (`train_row_limit`): TabPFN 1k, TabPFN v2 / Real-TabPFN / Mitra 10k, TabPFN v2.5 50k, TabICL 500k, TabPFN v3 / TabICL v2 1M, TabDPT unlimited. The cap is applied automatically when fitting; setting `config['general']['sample_size']` overrides it for a single run.
+
 
 
 > For researchers:


### PR DESCRIPTION
## Summary

This PR eliminates drift between the method registry and the config JSONs for foundation-model row limits, fixes the `torch.cuda.amp` / `use_reentrant` deprecation warnings, and removes duplicated code found during a package-wide consistency audit. No new features — only correctness, consistency, and a single source of truth.

## 1. Registry as single source of truth for training-row caps

Previously each foundation model's row cap lived in **two places** — `train_row_limit` in `model/method_registry.py` and `sample_size` in the default/opt_space config JSONs — and several had silently drifted (e.g. `tabicl_v2.json` said 60k while the registry said 1M; `tabdpt.json` capped at 100k while TabDPT is unlimited).

- New `Method.resolve_sample_size()` / `Method.subsample_train_rows()` helpers in `model/methods/base.py`: an explicit `config['general']['sample_size']` acts as a per-run override; otherwise the registry's `train_row_limit` applies.
- All foundation methods (`tabpfn`, `tabpfn_v2`, `tabpfn_real`, `tabpfn_v2_5`, `tabpfn_v3`, `tabicl`, `tabicl_v2`, `tabdpt`, `mitra`) now share this one seeded, stratified-for-classification subsampling path.
- `sample_size` removed from **all** default and opt_space config JSONs, so configs can no longer disagree with the registry.

Effective caps after this PR (registry-governed):

| Model | Before (config) | After (registry) |
|---|---|---|
| TabPFN (v1) | 3,000 | **1,000** |
| TabPFN v2 / Real-TabPFN | 10,000 | 10,000 |
| TabPFN v2.5 | 50,000 | 50,000 |
| TabPFN v3 | 1,000,000 | 1,000,000 |
| TabICL | uncapped | **500,000** |
| TabICL v2 | 60,000 | **1,000,000** |
| Mitra | uncapped at fit | **10,000** |
| TabDPT | 100,000 | **unlimited** |

## 2. Torch deprecation fixes

- `torch.cuda.amp.autocast(enabled=...)` → `torch.amp.autocast("cuda", enabled=...)` in `model/lib/tabpfn/utils.py` and `model/lib/limix/model/transformer.py`.
- `use_reentrant=False` added to all `torch.utils.checkpoint.checkpoint(...)` call sites in `model/lib/tabpfn/utils.py` and `model/lib/tabpfn/layer.py` (including the `partial(checkpoint, ...)` variant). This silences the current warnings and is required before torch makes the default a hard error.

## 3. Consistency / dead-code cleanup

- `check_softmax` was defined 7 times across the package; it now lives once in `model/utils.py` and is imported everywhere else (names remain importable from their old locations).
- Removed duplicate `import torch` statements from 11 method files.
- Mutable default arguments (`cat_indices=[]`) replaced with the `None` pattern in `tabpfn_v2.py`, `tabpfn_real.py`, `tabicl.py` (matching `tabpfn_v3.py`).
- Mitra `predict()` no longer raises `KeyError` when `max_samples_support` / `max_samples_query` are absent from the config (falls back to 8192 / 1024).
- `opt_space/tabpfn_v3.json` had drifted from the default config (`n_estimators` 4 vs 32, `sample_size` 50k vs 1M) — aligned.
- TabPFN v1's training subsample was unseeded (non-reproducible across runs); it now uses `args.seed` like every other method.
- README: documented that `train_row_limit` in the registry governs row caps and `sample_size` is a per-run override.

## Verification

- `python -m compileall` clean over `model/methods`, `model/classical_methods`, `model/utils.py`, `model/method_registry.py`, `api.py`.
- All config JSONs parse; no `sample_size` keys remain.
- Unit-tested the new helpers: registry default resolution, config override precedence, stratified classification subsampling, uniform regression subsampling, uncapped models pass through unchanged, unknown model types fall back to "no cap" without raising.
- Audited suspected bug `padding_obs_query__` in `mitra.py` — confirmed it matches the upstream Mitra `Tab2D.forward` signature (not a typo; unchanged).

## Fixes
- TabPFN v2 / Real-TabPFN: chunk test-set inference in 8,192-row blocks to bound the
  feature-attention CUDA kernel batch, fixing `CUDA error: invalid configuration argument`
  on wide datasets with large test sets (predictions are identical; rows are scored
  independently).
- Silence  `UndefinedMetricWarning`s  by passing `zero_division=0` to
  `precision_score` in both `metric()` implementations (reported values unchanged —
  sklearn already returned 0 for ill-defined precision).
