### PR TITLE
Fix MSE shape-broadcast bugs in GrowNet training and TabNet loss reporting; clean up ProtoGate tensor handling and dead config read

### DIFF
--- a/TALENT/model/methods/grownet.py
+++ b/TALENT/model/methods/grownet.py
@@ -87,7 +87,10 @@ class GrowNetMethod(Method):
                     middle_feat, out = self.model.forward(X_num, X_cat)
                     out = torch.as_tensor(out, dtype=torch.float64).cuda().view(-1, 1)
                     if self.is_regression:
-                        grad_direction = -(out - y)
+                        # y is (B,) while out is (B,1): without the view the
+                        # subtraction broadcasts to (B,B) and the MSE below is
+                        # computed over wrong sample pairs.
+                        grad_direction = -(out - y.view(-1, 1))
                         _, out = m(self.model.embed_input(X_num, X_cat), middle_feat)
                         out = torch.as_tensor(out, dtype=torch.float64).cuda().view(-1, 1)
                         loss = self.loss_f1(self.model.boost_rate * out, grad_direction)

--- a/TALENT/model/methods/protogate.py
+++ b/TALENT/model/methods/protogate.py
@@ -53,15 +53,18 @@ class ProtoGateMethod(Method):
         if config is not None:
             self.reset_stats_withconfig(config)
         self.data_format(is_train = True)
-        self.X_train = self.N['train'] 
-        self.y_neighbour = torch.tensor(self.y['train'])
+        self.X_train = self.N['train']
+        self.y_neighbour = self.y['train'].detach().clone()
         self.construct_model()
         self.optimizer = torch.optim.AdamW(
             self.model.parameters(), 
             lr=self.args.config['training']['lr'], 
             weight_decay=self.args.config['training']['weight_decay']
         )
-        self.feature_selection = self.args.config['model']['feature_selection'] if 'feature_selection' in self.args.config['training'].items() else True
+        # Note: `in dict.items()` would always be False (items are key-value
+        # tuples), so the config value was never read; the key lives in
+        # config['training'] (see utils.py default_para handling).
+        self.feature_selection = self.args.config['training'].get('feature_selection', True)
         self.pred_k = self.args.config['training']['pred_k']
         self.lam = self.args.config['training']['lam']
         self.sigma = self.args.config['model']['sigma']
@@ -110,7 +113,7 @@ class ProtoGateMethod(Method):
                     X_num, X_cat = X, None  
                         
                 x_selected, self.alpha, self.stochastic_gate = self.model(X_num)
-                x_neighbour_selected, _, _ = self.model(torch.tensor(self.X_train).to(x_selected.device))
+                x_neighbour_selected, _, _ = self.model(self.X_train.detach().clone().to(x_selected.device))
                 y_neighbour = self.y_neighbour.to(x_selected.device)
                 y_neighbour = F.one_hot(y_neighbour, num_classes=self.d_out)
 
@@ -181,7 +184,7 @@ class ProtoGateMethod(Method):
                 else:
                     X_num, X_cat = X, None                            
                 x_selected, self.alpha, self.stochastic_gate = self.model(X_num)
-                x_neighbour_selected, _, _ = self.model(torch.tensor(self.X_train).to(x_selected.device))
+                x_neighbour_selected, _, _ = self.model(self.X_train.detach().clone().to(x_selected.device))
                 y_neighbour = self.y_neighbour.to(x_selected.device)
                 y_neighbour = F.one_hot(y_neighbour, num_classes=self.d_out)
 

--- a/TALENT/model/methods/tabnet.py
+++ b/TALENT/model/methods/tabnet.py
@@ -116,7 +116,9 @@ class TabNetMethod(Method):
         tic = time.time()
         if self.is_regression:
             task_type = "regression"
-            test_logit = self.model.predict(self.N_test)
+            # TabNetRegressor returns (N, 1); flatten so the MSE loss below
+            # does not broadcast against the (N,) labels.
+            test_logit = self.model.predict(self.N_test).reshape(-1)
         else:
             task_type = "classification"
             test_logit = self.model.predict_proba(self.N_test)

--- a/TALENT/model/utils.py
+++ b/TALENT/model/utils.py
@@ -573,7 +573,7 @@ def tune_hyper_parameters(args, opt_space, train_val_data, info):
                 2,
                 256
             ]
-        except:
+        except KeyError:
             opt_space[args.model_type]['fit']['n_bins'] = [
                 "int",
                 2,


### PR DESCRIPTION
## Summary

Follow-up correctness pass over TALENT's first-party code, hunting the (B,1)-vs-(B) MSE
broadcast bug class and tensor-handling warnings. Two real broadcast instances found and
fixed (one of which affected training), plus three `torch.tensor(tensor)` re-wraps and a
config key that was silently never read. No API or behavior changes beyond the bug fixes.

## Fixes

### GrowNet: regression boosting trained on the wrong loss (real training bug)
In `model/methods/grownet.py`, the ensemble output `out` is `(B, 1)` while the loader's
`y` is `(B,)`. The gradient-boosting target `grad_direction = -(out - y)` therefore
broadcast to a **(B, B) matrix**, and the subsequent `MSELoss((B,1), (B,B))` was computed
over wrong sample pairs — silently degrading GrowNet regression training. Fixed by
aligning shapes with `y.view(-1, 1)`; the loss now pairs each prediction with its own
target. Classification branch untouched (different legacy math, behaves as published).

### TabNet: reported regression test loss computed over a broadcast matrix
`TabNetRegressor.predict` returns `(N, 1)`; the test labels are `(N,)`. The final
`F.mse_loss` in `model/methods/tabnet.py` therefore reported a meaningless broadcast
loss (metrics were unaffected — sklearn handles the column shape). The prediction is now
flattened to `(N,)`, which also makes the returned prediction shape consistent with the
other regressors.

### ProtoGate: tensor re-wrapping and a dead config read
- Replaced three `torch.tensor(existing_tensor)` calls (fit, predict, validate) with
  `.detach().clone()` — `self.y['train']` / `self.X_train` are already tensors at those
  points, so the old calls emitted "copy construct from a tensor" UserWarnings on every
  batch.
- `'feature_selection' in config['training'].items()` was always False (`.items()` yields
  key-value tuples), and the would-be read targeted `config['model']` where the key does
  not live — so the config value was silently ignored and the flag was always True. Now
  reads `config['training'].get('feature_selection', True)`: identical behavior with the
  shipped configs, but user overrides take effect.

### utils.py: narrowed a bare `except:` in `tune_hyper_parameters`
The training/fit `n_bins` fallback caught *all* exceptions (including
`KeyboardInterrupt`), which could mask real errors during HPO. Narrowed to
`except KeyError:` — the only exception the fallback is meant to handle.

## Assessed and intentionally NOT changed

- **`methods/base.py` train/validate/predict loss sites**: not a live bug — the
  regression criterion supplied by `data_loader_process` is `mse_safe_broadcast`
  (added in d7c5ebb / c3f0da9), which squeezes singleton dims and asserts shape
  equality before `mse_loss`. Verified no method reaches these loops with a raw
  `F.mse_loss` criterion. Broadcast warnings observed in older logs trace to the
  GrowNet/TabNet sites fixed above or to checkouts predating those commits.
- **`opt_space` mutation in the Optuna objective**: idempotent (writes the same
  constant each trial) and `opt_space` is loaded fresh per run — a per-trial deepcopy
  would add cost with zero observable effect.
- All other first-party `mse_loss` sites audited and confirmed shape-safe (tabptm,
  grande, switchtab, realmlp, dnnr, limix, and all foundation-model predict paths).

## Verification

- `python -m compileall` clean over all first-party modules.
- Numerical check of the GrowNet fix: gradient direction now `(B,1)` with row *i*
  paired to `y[i]` (previously `(B,B)`).
- Audited data pipeline (no train/test leakage), seed aggregation in `api.py`, and
  remaining `torch.tensor` call sites (all wrap numpy — correct usage).

