### PR TITLE
feat(hpo): configurable tuning metric (tune_metric) for hyperparameter search

### DIFF
--- a/TALENT/api.py
+++ b/TALENT/api.py
@@ -310,6 +310,7 @@ def build_args(
     except Exception:
         pass
 
+    base.setdefault("tune_metric", None)
     args = SimpleNamespace(**base)
 
     # Validate so we fail with a readable message rather than an obscure assert.
@@ -351,6 +352,7 @@ def run(
     verbose: bool = False,
     tune_threshold: bool = True,
     threshold_metric: str = "f1",
+    tune_metric: Optional[str] = None,
     **arg_overrides,
 ) -> RunResult:
     """Fit a TALENT method on ``train_val_data`` and predict on ``test_data``.
@@ -399,6 +401,14 @@ def run(
         on regression or multiclass tasks.
     threshold_metric : {"f1", "accuracy", "precision", "recall", "balanced_accuracy"}
         Which metric to optimise when tuning the threshold. Default ``"f1"``.
+    tune_metric : str, optional
+        Metric optimised during hyper-parameter search (e.g. ``"AUC"``,
+        ``"R2"``, ``"RMSE"``, ``"LogLoss"``). ``None`` (default) keeps TALENT's
+        historical HPO objective (validation Accuracy for classification,
+        MAE/RMSE for regression). See
+        ``TALENT.model.lib.tuning_metric.supported_tune_metrics()``. Not
+        supported for methods that tune on an internal loss (``tabnet``,
+        ``ptarl``, ``tabcaps``).
     **arg_overrides
         Passed through to :func:`build_args`.
 
@@ -414,6 +424,11 @@ def run(
             f"Set tune=False or pick a tunable method."
         )
 
+    from TALENT.model.lib.tuning_metric import (
+        validate_tune_metric, assert_tune_metric_supported,
+    )
+    validate_tune_metric(tune_metric)
+
     # Build args if not provided
     if args is None:
         args = build_args(
@@ -424,6 +439,7 @@ def run(
             seed_num=seed_num,
             tune=tune,
             n_trials=n_trials,
+            tune_metric=tune_metric,
             **arg_overrides,
         )
     else:
@@ -433,6 +449,8 @@ def run(
         if save_path is not None:
             args.save_path = save_path
             os.makedirs(save_path, exist_ok=True)
+        if tune_metric is not None:
+            args.tune_metric = tune_metric
 
     # Lazy imports — we don't want to drag torch in just for `list_methods()`.
     import torch
@@ -461,6 +479,7 @@ def run(
 
     # Optional HPO. The current `tune_hyper_parameters` mutates args.config.
     if tune and spec.supports_hpo:
+        assert_tune_metric_supported(model_type, args)
         # Load opt_space — required by tune_hyper_parameters
         _, opt_space = _try_load_method_config(model_type)
         if not opt_space:

--- a/TALENT/model/classical_methods/base.py
+++ b/TALENT/model/classical_methods/base.py
@@ -82,6 +82,35 @@ class classical_methods(object, metaclass=abc.ABCMeta):
         set_seeds(self.args.seed)
         self.config = self.args.config = config
 
+    def _val_proba(self, X):
+        """Validation-set class probabilities used for HPO metric selection.
+
+        Defaults to the fitted estimator's ``predict_proba``; subclasses
+        without one should override (e.g. distance-based ``NearestCentroid``).
+        """
+        return self.model.predict_proba(X)
+
+    def _record_best_res(self, val_features):
+        """Set ``trlog['best_res']`` for HPO, honouring ``args.tune_metric``.
+
+        With no ``tune_metric`` configured the historical behaviour is kept
+        exactly (validation accuracy for classification, std-scaled RMSE for
+        regression). Otherwise the configured metric is read from ``metric()``.
+        """
+        from TALENT.model.lib.tuning_metric import resolve_tune_metric, select_objective
+        from sklearn.metrics import accuracy_score, mean_squared_error
+        y_val = self.y['val']
+        if resolve_tune_metric(self.args) is None:
+            y_pred = self.model.predict(val_features)
+            if self.is_regression:
+                self.trlog['best_res'] = mean_squared_error(y_val, y_pred) ** 0.5 * self.y_info['std']
+            else:
+                self.trlog['best_res'] = accuracy_score(y_val, y_pred)
+            return
+        logit = self.model.predict(val_features) if self.is_regression else self._val_proba(val_features)
+        vres, names = self.metric(logit, y_val, self.y_info)
+        self.trlog['best_res'], _ = select_objective(vres, names, self.args, self.is_regression)
+
     def metric(self, predictions, labels, y_info, threshold=None):
         """Compute evaluation metrics.
 

--- a/TALENT/model/classical_methods/catboost.py
+++ b/TALENT/model/classical_methods/catboost.py
@@ -75,12 +75,7 @@ class CatBoostMethod(classical_methods):
         fit_config['eval_set'] = (X_val, self.y['val'])
         tic = time.time()
         self.model.fit(X_train, self.y['train'],**fit_config)
-        if not self.is_regression:
-            y_pred_val = self.model.predict(X_val)
-            self.trlog['best_res'] = accuracy_score(self.y['val'], y_pred_val) 
-        else:
-            y_pred_val = self.model.predict(X_val)
-            self.trlog['best_res'] = mean_squared_error(self.y['val'], y_pred_val) ** 0.5 * self.y_info['std']
+        self._record_best_res(X_val)
         time_cost = time.time() - tic
         with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)

--- a/TALENT/model/classical_methods/dummy.py
+++ b/TALENT/model/classical_methods/dummy.py
@@ -26,12 +26,7 @@ class DummyMethod(classical_methods):
             return
         tic = time.time()
         self.model.fit(self.N['train'], self.y['train'])
-        if not self.is_regression:
-            y_val_pred = self.model.predict(self.N['val'])
-            self.trlog['best_res'] = accuracy_score(self.y['val'], y_val_pred)
-        else:
-            y_val_pred = self.model.predict(self.N['val'])
-            self.trlog['best_res'] = mean_squared_error(self.y['val'], y_val_pred) ** 0.5 * self.y_info['std']
+        self._record_best_res(self.N['val'])
         time_cost = time.time() - tic
         with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)

--- a/TALENT/model/classical_methods/knn.py
+++ b/TALENT/model/classical_methods/knn.py
@@ -26,12 +26,7 @@ class KnnMethod(classical_methods):
             return
         tic = time.time()
         self.model.fit(self.N['train'], self.y['train'])
-        if not self.is_regression:
-            y_val_pred = self.model.predict(self.N['val'])
-            self.trlog['best_res'] = accuracy_score(self.y['val'], y_val_pred)
-        else:
-            y_val_pred = self.model.predict(self.N['val'])
-            self.trlog['best_res'] = mean_squared_error(self.y['val'], y_val_pred) ** 0.5 * self.y_info['std']
+        self._record_best_res(self.N['val'])
         time_cost = time.time() - tic
         with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)

--- a/TALENT/model/classical_methods/logreg.py
+++ b/TALENT/model/classical_methods/logreg.py
@@ -23,7 +23,7 @@ class LogRegMethod(classical_methods):
             return
         tic = time.time()
         self.model.fit(self.N['train'], self.y['train'])
-        self.trlog['best_res'] = self.model.score(self.N['val'], self.y['val'])
+        self._record_best_res(self.N['val'])
         time_cost = time.time() - tic
         with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)

--- a/TALENT/model/classical_methods/svm.py
+++ b/TALENT/model/classical_methods/svm.py
@@ -29,12 +29,7 @@ class SvmMethod(classical_methods):
             return
         tic = time.time()
         self.model.fit(self.N['train'], self.y['train'])
-        if not self.is_regression:
-            y_val_pred = self.model.predict(self.N['val'])
-            self.trlog['best_res'] = accuracy_score(self.y['val'], y_val_pred)
-        else:
-            y_val_pred = self.model.predict(self.N['val'])
-            self.trlog['best_res'] = mean_squared_error(self.y['val'], y_val_pred) ** 0.5 * self.y_info['std']
+        self._record_best_res(self.N['val'])
         time_cost = time.time() - tic
         with open(ops.join(self.args.save_path, 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)

--- a/TALENT/model/classical_methods/xgboost.py
+++ b/TALENT/model/classical_methods/xgboost.py
@@ -29,12 +29,7 @@ class XGBoostMethod(classical_methods):
         fit_config['eval_set'] = [(self.N['val'], self.y['val'])]
         tic = time.time()
         self.model.fit(self.N['train'], self.y['train'],**fit_config)
-        if not self.is_regression:
-            y_val_pred = self.model.predict(self.N['val'])
-            self.trlog['best_res'] = accuracy_score(self.y['val'], y_val_pred)
-        else:
-            y_val_pred = self.model.predict(self.N['val'])
-            self.trlog['best_res'] = mean_squared_error(self.y['val'], y_val_pred) ** 0.5 * self.y_info['std']
+        self._record_best_res(self.N['val'])
         time_cost = time.time() - tic
         with open(ops.join(self.args.save_path , 'best-val-{}.pkl'.format(self.args.seed)), 'wb') as f:
             pickle.dump(self.model, f)

--- a/TALENT/model/lib/tuning_metric.py
+++ b/TALENT/model/lib/tuning_metric.py
@@ -1,0 +1,144 @@
+"""Selectable objective metric for hyper-parameter optimization (HPO).
+
+By default TALENT optimizes the *first* metric returned by ``Method.metric``
+during tuning (historically: Accuracy for classification, MAE for the deep
+regressors / RMSE for the classical regressors). Setting ``args.tune_metric``
+to any metric name that ``Method.metric`` can emit makes the HPO search
+optimize that metric instead, in the correct direction.
+
+This is a generic TALENT feature: ``tune_metric`` is ``None`` by default, in
+which case the historical behaviour is preserved exactly, so existing results
+and downstream code are unaffected.
+
+Supported metric names (must match the names returned by ``Method.metric``):
+
+* Classification: ``Accuracy``, ``Avg_Recall``, ``Avg_Precision``, ``F1``,
+  ``LogLoss``, ``AUC``, ``Brier``, ``ECE``.
+* Regression: ``MAE``, ``R2``, ``RMSE``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence, Tuple
+
+# Whether a larger value of each metric means a better model. This is the
+# single source of truth for the optimization direction during HPO.
+_HIGHER_IS_BETTER = {
+    # --- classification ---
+    "Accuracy": True,
+    "Avg_Recall": True,
+    "Avg_Precision": True,
+    "F1": True,
+    "AUC": True,
+    "LogLoss": False,
+    "Brier": False,
+    "ECE": False,
+    # --- regression ---
+    "R2": True,
+    "MAE": False,
+    "RMSE": False,
+}
+
+
+def supported_tune_metrics() -> Tuple[str, ...]:
+    """Every metric name that can be passed as ``tune_metric``."""
+    return tuple(_HIGHER_IS_BETTER.keys())
+
+
+def metric_higher_is_better(name: str) -> bool:
+    """Return True if a larger value of ``name`` is better."""
+    return _HIGHER_IS_BETTER[name]
+
+
+def validate_tune_metric(name: Optional[str]) -> Optional[str]:
+    """Validate a requested ``tune_metric``; return it unchanged (or ``None``).
+
+    Raises ``ValueError`` for an unknown metric name so misconfiguration fails
+    fast rather than silently falling back.
+    """
+    if name is None:
+        return None
+    if name not in _HIGHER_IS_BETTER:
+        raise ValueError(
+            f"Unknown tune_metric {name!r}. Supported metrics: "
+            f"{', '.join(supported_tune_metrics())}."
+        )
+    return name
+
+
+def resolve_tune_metric(args) -> Optional[str]:
+    """Read ``args.tune_metric`` defensively (``None`` if unset)."""
+    return getattr(args, "tune_metric", None)
+
+
+def select_objective(
+    vres: Sequence[float],
+    metric_names: Sequence[str],
+    args,
+    is_regression: bool,
+) -> Tuple[float, bool]:
+    """Pick the HPO objective value + direction from a ``Method.metric`` result.
+
+    :param vres: the metric values returned by ``Method.metric``.
+    :param metric_names: the matching metric names.
+    :param args: the run arguments (read ``args.tune_metric``).
+    :param is_regression: whether the task is regression.
+    :return: ``(score, higher_is_better)``.
+
+    Falls back to the historical behaviour --- the first metric in ``vres``,
+    with ``higher_is_better == (not is_regression)`` --- when no ``tune_metric``
+    is configured, when the requested metric is not available for this task
+    (e.g. ``AUC`` on a regression task), or when the value is NaN (e.g. ``AUC``
+    on a degenerate single-class validation fold).
+    """
+    legacy = (float(vres[0]), (not is_regression))
+    key = resolve_tune_metric(args)
+    if not key or key not in metric_names:
+        return legacy
+    val = vres[list(metric_names).index(key)]
+    try:
+        val = float(val)
+    except (TypeError, ValueError):
+        return legacy
+    if math.isnan(val):
+        return legacy
+    return val, _HIGHER_IS_BETTER.get(key, not is_regression)
+
+
+def study_direction(args, is_regression: bool) -> str:
+    """Optuna study direction (``'maximize'``/``'minimize'``) for the metric.
+
+    Mirrors :func:`select_objective`: defaults to ``'minimize'`` for regression
+    and ``'maximize'`` for classification when no ``tune_metric`` is set.
+    """
+    key = resolve_tune_metric(args)
+    if not key or key not in _HIGHER_IS_BETTER:
+        return "minimize" if is_regression else "maximize"
+    return "maximize" if _HIGHER_IS_BETTER[key] else "minimize"
+
+
+def worst_objective_value(args, is_regression: bool) -> float:
+    """A sentinel "worst" score for the configured direction.
+
+    Used as the objective's return value when a trial raises, so a failed
+    trial is never selected as best regardless of optimization direction.
+    """
+    return -1e18 if study_direction(args, is_regression) == "maximize" else 1e18
+
+
+# Methods whose HPO objective is an internal training loss rather than a value
+# returned by ``Method.metric`` (so a user-selected ``tune_metric`` cannot be
+# applied to them). Tuning these still works with ``tune_metric=None``.
+METHODS_WITHOUT_TUNE_METRIC = frozenset({"tabnet", "ptarl", "tabcaps"})
+
+
+def assert_tune_metric_supported(model_type: str, args) -> None:
+    """Raise if a ``tune_metric`` is set for a method that cannot honour it."""
+    if resolve_tune_metric(args) is not None and model_type in METHODS_WITHOUT_TUNE_METRIC:
+        raise NotImplementedError(
+            f"tune_metric is not supported for method {model_type!r}, which tunes "
+            f"on its internal training loss rather than a Method.metric output. "
+            f"Use tune_metric=None for this method, or exclude it from "
+            f"metric-specific HPO."
+        )

--- a/TALENT/model/methods/base.py
+++ b/TALENT/model/methods/base.py
@@ -337,8 +337,11 @@ class Method(object, metaclass=abc.ABCMeta):
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
 
         print('epoch {}, val, loss={:.4f} {} result={:.4f}'.format(epoch, vl, task_type, vres[0]))
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             torch.save(
                 dict(params=self.model.state_dict()),

--- a/TALENT/model/methods/dnnr.py
+++ b/TALENT/model/methods/dnnr.py
@@ -82,7 +82,8 @@ class DNNRMethod(Method):
         test_label = torch.from_numpy(test_label)
         
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
-        self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        self.trlog['best_res'], _ = select_objective(vres, metric_name, self.args, self.is_regression)
 
 
     def predict(self, data, info, model_name):

--- a/TALENT/model/methods/grande.py
+++ b/TALENT/model/methods/grande.py
@@ -265,8 +265,11 @@ class GRANDEMethod(Method):
 
         print('epoch {}, val, loss={:.4f} {} result={:.4f}'.format(epoch, vl, task_type, vres[0]))
 
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             torch.save(
                 dict(params=self.model.state_dict()),

--- a/TALENT/model/methods/grownet.py
+++ b/TALENT/model/methods/grownet.py
@@ -177,8 +177,11 @@ class GrowNetMethod(Method):
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
 
         print('epoch {}, val, loss={:.4f} {} result={:.4f}'.format(epoch, vl, task_type, vres[0]))
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             self.model.to_file(self.args.save_path + "/final-{}.pt".format(str(self.args.seed)))
             self.val_count = 0

--- a/TALENT/model/methods/modernNCA.py
+++ b/TALENT/model/methods/modernNCA.py
@@ -316,8 +316,11 @@ class ModernNCAMethod(Method):
             measure = np.greater_equal
 
         print('epoch {}, val, loss={:.4f} {} result={:.4f}'.format(epoch, vl, task_type, vres[0]))
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             torch.save(
                 dict(params=self.model.state_dict()),

--- a/TALENT/model/methods/protogate.py
+++ b/TALENT/model/methods/protogate.py
@@ -208,8 +208,11 @@ class ProtoGateMethod(Method):
 
 
         print('epoch {}, val, {} result={:.4f}'.format(epoch,  task_type, vres[0]))
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             torch.save(
                 dict(params=self.model.state_dict()),

--- a/TALENT/model/methods/realmlp.py
+++ b/TALENT/model/methods/realmlp.py
@@ -122,7 +122,8 @@ class RealMLPMethod(Method):
         test_label = torch.from_numpy(test_label)
         
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
-        self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        self.trlog['best_res'], _ = select_objective(vres, metric_name, self.args, self.is_regression)
 
 
     def predict(self, data, info, model_name):

--- a/TALENT/model/methods/t2gformer.py
+++ b/TALENT/model/methods/t2gformer.py
@@ -68,8 +68,11 @@ class T2GFormerMethod(Method):
 
 
         print('epoch {}, val, loss={:.4f} {} result={:.4f}'.format(epoch, vl, task_type, vres[0]))
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             torch.save(
                 dict(params=self.model.state_dict()),

--- a/TALENT/model/methods/tabm.py
+++ b/TALENT/model/methods/tabm.py
@@ -167,8 +167,11 @@ class TabMMethod(Method):
 
 
         print('epoch {}, val, loss={:.4f} {} result={:.4f}'.format(epoch, vl, task_type, vres[0]))
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             torch.save(
                 dict(params=self.model.state_dict()),

--- a/TALENT/model/methods/tabptm.py
+++ b/TALENT/model/methods/tabptm.py
@@ -414,8 +414,11 @@ class TabPTMMethod(Method):
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
             
         print('epoch {}, val, loss={:.4f} {} result={:.4f}'.format(epoch, vl, task_type, vres[0]))
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             torch.save(
                 dict(params=self.model.state_dict()),

--- a/TALENT/model/methods/tabr.py
+++ b/TALENT/model/methods/tabr.py
@@ -301,8 +301,11 @@ class TabRMethod(Method):
         vres, metric_name = self.metric(test_logit, test_label, self.y_info)
 
         print('epoch {}, val, loss={:.4f} {} result={:.4f}'.format(epoch, vl, task_type, vres[0]))
-        if measure(vres[0], self.trlog['best_res']) or epoch == 0:
-            self.trlog['best_res'] = vres[0]
+        from TALENT.model.lib.tuning_metric import select_objective
+        _score, _higher = select_objective(vres, metric_name, self.args, self.is_regression)
+        measure = np.greater_equal if _higher else np.less_equal
+        if measure(_score, self.trlog['best_res']) or epoch == 0:
+            self.trlog['best_res'] = _score
             self.trlog['best_epoch'] = epoch
             torch.save(
                 dict(params=self.model.state_dict()),

--- a/TALENT/model/utils.py
+++ b/TALENT/model/utils.py
@@ -313,6 +313,9 @@ def get_classical_args():
 
     # other choices
     parser.add_argument('--n_trials', type=int, default=default_args['n_trials'])
+    parser.add_argument('--tune_metric', type=str, default=None,
+                        help="HPO objective metric (e.g. AUC, R2, RMSE, LogLoss). "
+                             "None keeps the legacy default (Accuracy / MAE-RMSE).")
     parser.add_argument('--seed_num', type=int, default=default_args['seed_num'])
     parser.add_argument('--gpu', default=default_args['gpu'])
     parser.add_argument('--tune', action='store_true', default=default_args['tune'])
@@ -399,6 +402,9 @@ def get_deep_args():
 
     # other choices
     parser.add_argument('--n_trials', type=int, default=default_args['n_trials'])
+    parser.add_argument('--tune_metric', type=str, default=None,
+                        help="HPO objective metric (e.g. AUC, R2, RMSE, LogLoss). "
+                             "None keeps the legacy default (Accuracy / MAE-RMSE).")
     parser.add_argument('--seed_num', type=int, default=default_args['seed_num'])
     parser.add_argument('--workers', type=int, default=default_args['workers'])
     parser.add_argument('--gpu', default=default_args['gpu'])
@@ -709,21 +715,24 @@ def tune_hyper_parameters(args, opt_space, train_val_data, info):
             return method.trlog['best_res']
         except Exception as e:
             print(e)
-            return 1e9 if info['task_type'] == 'regression' else 0.0
+            from TALENT.model.lib.tuning_metric import worst_objective_value
+            return worst_objective_value(args, info['task_type'] == 'regression')
 
     if osp.exists(osp.join(args.save_path, '{}-tuned.json'.format(args.model_type))) and args.retune == False:
         with open(osp.join(args.save_path, '{}-tuned.json'.format(args.model_type)), 'rb') as fp:
             args.config = json.load(fp)
     else:
-        # get data property
-        if info['task_type'] == 'regression':
-            direction = 'minimize'
+        # get data property. The optimization direction follows the configured
+        # tune_metric (defaults to minimize for regression / maximize for
+        # classification when tune_metric is unset).
+        from TALENT.model.lib.tuning_metric import study_direction
+        is_reg = info['task_type'] == 'regression'
+        direction = study_direction(args, is_reg)
+        if is_reg:
             for key in opt_space[args.model_type]['model'].keys():
                 if 'dropout' in key and '?' not in opt_space[args.model_type]['model'][key][0]:
                     opt_space[args.model_type]['model'][key][0] = '?' + opt_space[args.model_type]['model'][key][0]
                     opt_space[args.model_type]['model'][key].insert(1, 0.0)
-        else:
-            direction = 'maximize'
 
         method = get_method(args.model_type)(args, info['task_type'] == 'regression')
 

--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,29 @@ print("Mean metrics:", dict(zip(result.metric_names, result.metrics_mean)))
 print("Std metrics:",  dict(zip(result.metric_names, result.metrics_std)))
 ```
 
+#### Choosing the HPO objective metric
+
+By default the hyperparameter search optimizes TALENT's historical objective
+(validation **Accuracy** for classification, **MAE / RMSE** for regression).
+Pass `tune_metric` to optimize any metric that `Method.metric` reports instead;
+the optimization direction is inferred automatically.
+
+```python
+# Tune on ROC-AUC (classification) or R2 (regression) rather than the default
+result = TALENT.run("catboost", train_val, test, info,
+                    tune=True, n_trials=50, tune_metric="AUC")
+
+from TALENT.model.lib.tuning_metric import supported_tune_metrics
+print(supported_tune_metrics())
+# ('Accuracy', 'Avg_Recall', 'Avg_Precision', 'F1', 'AUC',
+#  'LogLoss', 'Brier', 'ECE', 'R2', 'MAE', 'RMSE')
+```
+
+`tune_metric` is also exposed on the CLI (`--tune_metric AUC`). It defaults to
+`None`, which preserves the previous behavior exactly. A few methods optimize an
+internal training loss and do not accept it (`tabnet`, `ptarl`, `tabcaps`); use
+the default for those.
+
 Introspect or filter methods via the unified registry:
 
 ```python


### PR DESCRIPTION
## Configurable HPO objective metric (`tune_metric`)

Adds a general option to choose which validation metric the hyperparameter
search optimizes, instead of the hard-coded default (validation **Accuracy**
for classification, **MAE/RMSE** for regression).

### Usage
```python
TALENT.run("catboost", train_val, test, info, tune=True, n_trials=50, tune_metric="AUC")