### PR TITLE
Add TabFM and fix foundation-model integration bugs

### DIFF
--- a/TALENT/api.py
+++ b/TALENT/api.py
@@ -343,10 +343,10 @@ def run(
     *,
     config: Optional[Dict[str, Any]] = None,
     args: Optional[SimpleNamespace] = None,
-    seed: int = 0,
-    seed_num: int = 1,
-    tune: bool = False,
-    n_trials: int = 50,
+    seed: Optional[int] = None,
+    seed_num: Optional[int] = None,
+    tune: Optional[bool] = None,
+    n_trials: Optional[int] = None,
     save_path: Optional[str] = None,
     return_method: bool = False,
     verbose: bool = False,
@@ -372,19 +372,22 @@ def run(
     config : dict, optional
         Method-specific config. If None, the packaged default is used.
     args : SimpleNamespace, optional
-        Pre-built args. If supplied, all of the per-call kwargs below are
-        ignored (you can also pass `seed` to override `args.seed`). Pass
-        the output of :func:`build_args` here when you want fine control.
-    seed : int, default 0
-        Random seed (used when seed_num == 1).
-    seed_num : int, default 1
+        Pre-built args. If supplied, its fields are used as defaults; explicit
+        per-call kwargs below override matching fields. Pass the output of
+        :func:`build_args` here when you want fine control.
+    seed : int, optional
+        Random seed (used when seed_num == 1). Defaults to 0 when `args` is
+        not supplied.
+    seed_num : int, optional
         Run multiple seeds (0..seed_num-1) and aggregate metrics. The
         returned `predictions` are from the *last* seed; per-seed details
-        are in `result.per_seed`.
-    tune : bool, default False
-        If True and the method supports HPO, run Optuna tuning first.
-    n_trials : int, default 50
-        Optuna trial budget (when tune=True).
+        are in `result.per_seed`. Defaults to 1 when `args` is not supplied.
+    tune : bool, optional
+        If True and the method supports HPO, run Optuna tuning first. Defaults
+        to False when `args` is not supplied.
+    n_trials : int, optional
+        Optuna trial budget (when tune=True). Defaults to 50 when `args` is
+        not supplied.
     save_path : str, optional
         Where to save checkpoints / tuned configs. Auto-generated if None.
     return_method : bool, default False
@@ -418,19 +421,13 @@ def run(
     """
     spec = get_method_spec(model_type)
 
-    if tune and not spec.supports_hpo:
-        raise ValueError(
-            f"Method {model_type!r} does not support HPO. "
-            f"Set tune=False or pick a tunable method."
-        )
-
-    from TALENT.model.lib.tuning_metric import (
-        validate_tune_metric, assert_tune_metric_supported,
-    )
-    validate_tune_metric(tune_metric)
-
-    # Build args if not provided
+    # Build args if not provided. With a pre-built args object, preserve its
+    # values unless the caller explicitly passes the matching optional kwarg.
     if args is None:
+        seed = 0 if seed is None else seed
+        seed_num = 1 if seed_num is None else seed_num
+        tune = False if tune is None else tune
+        n_trials = 50 if n_trials is None else n_trials
         args = build_args(
             model_type,
             save_path=save_path,
@@ -446,11 +443,33 @@ def run(
         # Honour late overrides
         if seed is not None:
             args.seed = seed
+        if seed_num is not None:
+            args.seed_num = seed_num
+        if tune is not None:
+            args.tune = tune
+        if n_trials is not None:
+            args.n_trials = n_trials
         if save_path is not None:
             args.save_path = save_path
             os.makedirs(save_path, exist_ok=True)
         if tune_metric is not None:
             args.tune_metric = tune_metric
+        args.seed = getattr(args, "seed", 0)
+        args.seed_num = getattr(args, "seed_num", 1)
+        args.tune = getattr(args, "tune", False)
+        args.n_trials = getattr(args, "n_trials", 50)
+        args.tune_metric = getattr(args, "tune_metric", None)
+
+    from TALENT.model.lib.tuning_metric import (
+        validate_tune_metric, assert_tune_metric_supported,
+    )
+    validate_tune_metric(args.tune_metric)
+
+    if args.tune and not spec.supports_hpo:
+        raise ValueError(
+            f"Method {model_type!r} does not support HPO. "
+            f"Set tune=False or pick a tunable method."
+        )
 
     # Lazy imports — we don't want to drag torch in just for `list_methods()`.
     import torch
@@ -478,7 +497,7 @@ def run(
     method_cls = spec.get_class()
 
     # Optional HPO. The current `tune_hyper_parameters` mutates args.config.
-    if tune and spec.supports_hpo:
+    if args.tune and spec.supports_hpo:
         assert_tune_metric_supported(model_type, args)
         # Load opt_space — required by tune_hyper_parameters
         _, opt_space = _try_load_method_config(model_type)
@@ -503,8 +522,9 @@ def run(
     predict_times: List[float] = []
     method = None
 
-    for s in range(seed_num):
-        args.seed = s if seed_num > 1 else seed
+    initial_seed = args.seed
+    for s in range(args.seed_num):
+        args.seed = s if args.seed_num > 1 else initial_seed
         set_seeds(args.seed)
         if verbose:
             print(f"[TALENT.api.run] seed={args.seed} method={model_type}")
@@ -562,7 +582,7 @@ def run(
         last_threshold = eval_result["threshold"]
 
     # Aggregate
-    if seed_num > 1:
+    if args.seed_num > 1:
         loss_mean, loss_std, m_mean, m_std = _aggregate_metrics(per_seed, last_metric_names)
     else:
         loss_mean = per_seed[0]["loss"]

--- a/TALENT/configs/default/tabfm.json
+++ b/TALENT/configs/default/tabfm.json
@@ -1,0 +1,15 @@
+{
+    "tabfm": {
+        "model": {},
+        "training": {},
+        "general": {
+            "backend": "pytorch",
+            "n_estimators": 32,
+            "max_num_features": 500,
+            "batch_size": 1,
+            "use_amp": true,
+            "use_cache": true,
+            "ensemble": false
+        }
+    }
+}

--- a/TALENT/configs/opt_space/tabfm.json
+++ b/TALENT/configs/opt_space/tabfm.json
@@ -1,0 +1,15 @@
+{
+    "tabfm": {
+        "model": {},
+        "training": {},
+        "general": {
+            "backend": "pytorch",
+            "n_estimators": 32,
+            "max_num_features": 500,
+            "batch_size": 1,
+            "use_amp": true,
+            "use_cache": true,
+            "ensemble": false
+        }
+    }
+}

--- a/TALENT/configs/opt_space/tabptm.json
+++ b/TALENT/configs/opt_space/tabptm.json
@@ -1,5 +1,5 @@
 {
-    "tabpfn": {
+    "tabptm": {
         "model": {},
         "training": {},
         "general": {}

--- a/TALENT/model/lib/data.py
+++ b/TALENT/model/lib/data.py
@@ -320,9 +320,10 @@ def data_enc_process(N_data, C_data, cat_policy, y_train = None, ord_encoder = N
             for column_idx in range(C_data['test'].shape[1]):
                 C_data['test'][:, column_idx][C_data['test'][:, column_idx] == unknown_value] = mode_values[column_idx]
         elif 'val' in C_data.keys():
-            mode_values = [np.argmax(np.bincount(column[column != unknown_value]))
-                        if np.any(column == unknown_value) else column[0]
-                        for column in C_data['train'].T]
+            mode_values = []
+            for column in C_data['train'].T:
+                known_values = column[column != unknown_value].astype(np.int64)
+                mode_values.append(int(np.argmax(np.bincount(known_values))))
             for column_idx in range(C_data['val'].shape[1]):
                 C_data['val'][:, column_idx][C_data['val'][:, column_idx] == unknown_value] = mode_values[column_idx]
 
@@ -439,6 +440,8 @@ def data_label_process(y_data, is_regression, info = None, encoder = None):
             mean, std = y_data['train'].mean(), y_data['train'].std()
         else:
             mean, std = info['mean'], info['std']
+        if std == 0:
+            std = 1.0
         y = {k: (v - mean) / std for k, v in y.items()}
         info = {'policy': 'mean_std', 'mean': mean, 'std': std}
         return y, info, None

--- a/TALENT/model/method_registry.py
+++ b/TALENT/model/method_registry.py
@@ -328,6 +328,13 @@ _METHODS_DEEP = [
           supports_hpo=False,
           notes="TabDPT (Layer 6 AI). ICL + retrieval; supports both "
                 "classification and regression. External `tabdpt` package."),
+    _spec("tabfm", "TALENT.model.methods.tabfm", "TabFMMethod",
+          _DEEP, _GPU, _PROBS, cat_policy=("indices",),
+          normalization="none", num_policy="none",
+          supports_hpo=False,
+          notes="TabFM v1.0.0 (Google Research). Zero-shot ICL foundation "
+                "model via optional `tabfm[pytorch]`; classification is "
+                "limited to 10 classes by the upstream model."),
 ]
 
 

--- a/TALENT/model/methods/tabfm.py
+++ b/TALENT/model/methods/tabfm.py
@@ -1,0 +1,243 @@
+"""TabFM method.
+
+TabFM (`google-research/tabfm`) is Google's zero-shot tabular foundation
+model. It exposes a scikit-learn compatible API through the optional
+``tabfm`` package.
+
+Setup:
+    pip install -U "tabfm[pytorch]"
+"""
+
+import inspect
+import time
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn.functional as F
+
+from TALENT.model.lib.data import (
+    Dataset,
+    data_label_process,
+    data_nan_process,
+)
+from TALENT.model.methods.base import Method
+
+
+class TabFMMethod(Method):
+    """TabFM zero-shot classifier/regressor wrapper."""
+
+    def __init__(self, args, is_regression):
+        super().__init__(args, is_regression)
+        assert args.normalization == "none"
+        assert args.cat_policy == "indices"
+        assert args.num_policy == "none"
+        assert args.tune is not True
+
+    def data_format(self, is_train=True, N=None, C=None, y=None):
+        if is_train:
+            self.N, self.C, self.num_new_value, self.imputer, self.cat_new_value = data_nan_process(
+                self.N, self.C, self.args.num_nan_policy, self.args.cat_nan_policy
+            )
+            self.y, self.y_info, self.label_encoder = data_label_process(
+                self.y, self.is_regression
+            )
+            self.criterion = F.mse_loss if self.is_regression else F.cross_entropy
+        else:
+            N_test, C_test, _, _, _ = data_nan_process(
+                N,
+                C,
+                self.args.num_nan_policy,
+                self.args.cat_nan_policy,
+                self.num_new_value,
+                self.imputer,
+                self.cat_new_value,
+            )
+            y_test, _, _ = data_label_process(
+                y, self.is_regression, self.y_info, self.label_encoder
+            )
+            self.N_test = None if N_test is None else N_test["test"]
+            self.C_test = None if C_test is None else C_test["test"]
+            self.y_test = y_test["test"]
+
+    def _to_frame(self, N_part, C_part):
+        columns = []
+        parts = []
+        if N_part is not None:
+            N_part = np.asarray(N_part)
+            parts.append(N_part)
+            columns.extend([f"num_{i}" for i in range(N_part.shape[1])])
+        if C_part is not None:
+            C_part = np.asarray(C_part).astype(str)
+            parts.append(C_part)
+            columns.extend([f"cat_{i}" for i in range(C_part.shape[1])])
+        if not parts:
+            raise ValueError("TabFM requires at least one feature column.")
+        X = np.concatenate(parts, axis=1) if len(parts) > 1 else parts[0]
+        df = pd.DataFrame(X, columns=columns)
+        for col in df.columns:
+            if col.startswith("num_"):
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            else:
+                df[col] = df[col].astype("category")
+        return df
+
+    def _subsample_frame(self, X, y):
+        sample_size = self.resolve_sample_size()
+        if sample_size is None or len(X) <= sample_size:
+            return X, y
+        if not self.is_regression:
+            from sklearn.model_selection import train_test_split
+
+            X_sample, _, y_sample, _ = train_test_split(
+                X,
+                y,
+                train_size=sample_size,
+                stratify=y,
+                random_state=self.args.seed,
+            )
+            return X_sample.reset_index(drop=True), y_sample
+        rng = np.random.RandomState(self.args.seed)
+        idx = rng.choice(len(X), size=sample_size, replace=False)
+        return X.iloc[idx].reset_index(drop=True), y[idx]
+
+    def _load_tabfm_model(self):
+        general = self.args.config.get("general", {}) or {}
+        backend = general.get("backend", "pytorch")
+        if backend != "pytorch":
+            raise ValueError(
+                "TALENT's TabFM wrapper currently supports backend='pytorch'. "
+                "Install with: pip install -U \"tabfm[pytorch]\"."
+            )
+        try:
+            from tabfm import tabfm_v1_0_0_pytorch as tabfm_v1_0_0
+        except ImportError as e:
+            raise ImportError(
+                "TabFM requires the optional `tabfm` package with the PyTorch "
+                "backend. Install it via: pip install -U \"tabfm[pytorch]\"."
+            ) from e
+
+        load_kwargs = {
+            "model_type": "regression" if self.is_regression else "classification",
+            "device": str(self.args.device),
+            "use_cache": general.get("use_cache", True),
+        }
+        for key in ("checkpoint_path", "dtype"):
+            if key in general:
+                load_kwargs[key] = general[key]
+        return tabfm_v1_0_0.load(**load_kwargs)
+
+    def construct_model(self, model_config=None, cat_indices=None):
+        try:
+            from tabfm import TabFMClassifier, TabFMRegressor
+        except ImportError as e:
+            raise ImportError(
+                "TabFM requires the optional `tabfm` package. Install it via: "
+                "pip install -U \"tabfm[pytorch]\"."
+            ) from e
+
+        general = self.args.config.get("general", {}) or {}
+        model = self._load_tabfm_model()
+        target_cls = TabFMRegressor if self.is_regression else TabFMClassifier
+
+        wrapper_kwargs = {"model": model, "random_state": self.args.seed}
+        for key in (
+            "n_estimators",
+            "norm_methods",
+            "feat_shuffle_method",
+            "class_shift",
+            "permute_categorical",
+            "outlier_threshold",
+            "max_num_features",
+            "max_num_rows",
+            "softmax_temperature",
+            "average_logits",
+            "use_amp",
+            "batch_size",
+            "verbose",
+            "cat_encoder_mode",
+            "binary_calibration_method",
+            "multiclass_calibration_method",
+            "num_folds_for_cv",
+            "n_feature_crosses",
+            "n_svd_features",
+            "total_svd_pool",
+            "enable_nnls",
+            "nnls_beta",
+            "calibration_lambda",
+            "min_rows_for_single_val_split",
+        ):
+            if key in general:
+                wrapper_kwargs[key] = general[key]
+
+        accepted = set(inspect.signature(target_cls.__init__).parameters)
+        wrapper_kwargs = {k: v for k, v in wrapper_kwargs.items() if k in accepted}
+        if general.get("ensemble", False):
+            self.model = target_cls.ensemble(model, **{
+                k: v for k, v in wrapper_kwargs.items() if k != "model"
+            })
+        else:
+            self.model = target_cls(**wrapper_kwargs)
+
+    def fit(self, data, info, train=True, config=None):
+        N, C, y = data
+        self.D = Dataset(N, C, y, info)
+        self.N, self.C, self.y = self.D.N, self.D.C, self.D.y
+        self.is_binclass, self.is_multiclass, self.is_regression = (
+            self.D.is_binclass,
+            self.D.is_multiclass,
+            self.D.is_regression,
+        )
+        self.data_format(is_train=True)
+
+        if not self.is_regression and self.y_info["n_classes"] > 10:
+            raise ValueError(
+                "TabFM v1.0.0 supports classification with at most 10 classes; "
+                f"got {self.y_info['n_classes']}."
+            )
+
+        X_train = self._to_frame(
+            None if self.N is None else self.N["train"],
+            None if self.C is None else self.C["train"],
+        )
+        y_train = self.y["train"]
+        X_train, y_train = self._subsample_frame(X_train, y_train)
+        self.sampled_X = X_train
+        self.sampled_Y = y_train
+        self.construct_model()
+
+        tic = time.time()
+        self.model.fit(X_train, y_train)
+        self.fit_time = time.time() - tic
+
+    def predict(self, data, info, model_name):
+        N, C, y = data
+        self.data_format(False, N, C, y)
+        X_test = self._to_frame(self.N_test, self.C_test)
+
+        tic = time.time()
+        if self.is_regression:
+            test_logit = self.model.predict(X_test)
+        else:
+            test_logit = self.model.predict_proba(X_test)
+        self.predict_time = time.time() - tic
+
+        test_logit = np.asarray(test_logit).astype(np.float32)
+        test_label = self.y_test
+        if self.is_regression:
+            t_pred = torch.tensor(test_logit).reshape(-1)
+            t_lab = torch.tensor(test_label, dtype=torch.float32).reshape(-1)
+            vl = self.criterion(t_pred, t_lab).item()
+        else:
+            vl = self.criterion(
+                torch.tensor(test_logit), torch.tensor(test_label)
+            ).item()
+        vres, metric_name = self.metric(test_logit, test_label, self.y_info)
+
+        if self.is_regression and self.y_info.get("policy") == "mean_std":
+            test_logit = test_logit * self.y_info["std"] + self.y_info["mean"]
+
+        print("Test: loss={:.4f}".format(vl))
+        for name, res in zip(metric_name, vres):
+            print("[{}]={:.4f}".format(name, res))
+        return vl, vres, metric_name, test_logit

--- a/TALENT/model/methods/tabptm.py
+++ b/TALENT/model/methods/tabptm.py
@@ -315,8 +315,8 @@ class TabPTMMethod(Method):
 
             num_per_subset = numK // num_class
             remainder = numK % num_class
-            X_meta_new = torch.zeros(batch_size, numK).cuda()
-            label_dist = torch.zeros(batch_size, numK).cuda()
+            X_meta_new = torch.zeros(batch_size, numK, device=X_meta.device)
+            label_dist = torch.zeros(batch_size, numK, device=X_meta.device)
             for i in range(num_class):
                 subset = X_meta_dist[:, i, :].topk(num_per_subset, dim=1, largest=False).values
                 start_idx = i * num_per_subset
@@ -342,9 +342,10 @@ class TabPTMMethod(Method):
 
         X_meta = torch.stack(X_meta_dist_list).permute([1, 0, 2]).unsqueeze(1).expand(-1, num_class, -1, -1)
         label = torch.stack(label_dist_list).permute([1, 0, 2]).unsqueeze(1).expand(-1, num_class, -1, -1)
-        mask_tensor = torch.ones_like(label).cuda() * -1.0
+        mask_tensor = torch.ones_like(label) * -1.0
 
-        mask_tensor[label == torch.arange(num_class).cuda().unsqueeze(0).unsqueeze(2).unsqueeze(3)] = 1.0
+        class_ids = torch.arange(num_class, device=label.device).unsqueeze(0).unsqueeze(2).unsqueeze(3)
+        mask_tensor[label == class_ids] = 1.0
         X_meta = torch.cat((X_meta,mask_tensor),dim=-1)
         return X_meta.double()
 
@@ -429,4 +430,4 @@ class TabPTMMethod(Method):
             self.val_count += 1
             if self.val_count > 20:
                 self.continue_training = False
-        torch.save(self.trlog, osp.join(self.args.save_path, 'trlog'))   
+        torch.save(self.trlog, osp.join(self.args.save_path, 'trlog'))

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Welcome to **TALENT**, a benchmark with a comprehensive machine learning toolbox
 
 ## 📰 What's New
 
+- [2026-07]🌟 Add **[TabFM](https://github.com/google-research/tabfm)** (Google Research, zero-shot tabular foundation model) as an optional method via `pip install -U "tabfm[pytorch]"`.
 - [2026-06]🌟 Add **[TabPFN v2.5](https://arxiv.org/abs/2511.08667)** (PriorLabs, Nov 2025) and **[TabDPT](https://github.com/layer6ai-labs/TabDPT-inference)** (Layer 6 AI, ICL + retrieval). TALENT now ships the full TabPFN family (v1, v2, v2.5, v3) plus TabDPT alongside the other tabular foundation models.
 - [2026-06]🌟 Evaluation improvements: **calibration metrics** (Brier, ECE) are now reported by default for every classifier, **decision thresholds** are tuned on the validation set for binary classification (used for Accuracy/F1/Precision/Recall; threshold-independent metrics like AUC/LogLoss/Brier/ECE are unaffected), and `RunResult` exposes a uniform `predict_proba`/`predict_labels` interface regardless of whether the underlying method natively returns logits or probabilities. Bundled checkpoints are now resolved via `importlib.resources` so methods work from any working directory.
 - [2026-05]🌟 Add [TabPFN v3](https://github.com/PriorLabs/TabPFN) (PriorLabs 2026) and [TabICL v2](https://github.com/soda-inria/tabicl) (ICML 2026, regression support added).
@@ -159,6 +160,7 @@ TALENT integrates an extensive array of 30+ deep learning architectures for tabu
 42. **[TabICL v2](https://github.com/soda-inria/tabicl)**: TabICL v2 (ICML 2026), now supporting both classification and regression (via `TabICLRegressor`), with native quantile regression. Requires `pip install -U 'tabicl>=2.0.0'`.
 43. **[TabPFN v2.5](https://arxiv.org/abs/2511.08667)**: TabPFN v2.5 (PriorLabs, Nov 2025), the intermediate release between v2 and v3. Scales in-context learning to ~50k rows × 2k features. Requires `pip install -U 'tabpfn>=8.0.0'`.
 44. **[TabDPT](https://github.com/layer6ai-labs/TabDPT-inference)**: A tabular foundation model from Layer 6 AI that combines in-context learning with retrieval and self-supervised pre-training on real data, removing fixed context-size limits. Requires `pip install -U tabdpt`.
+45. **[TabFM](https://github.com/google-research/tabfm)**: Google's zero-shot tabular foundation model for classification and regression, using in-context learning over training rows as context. Requires `pip install -U "tabfm[pytorch]"`; the upstream model weights use the TabFM Non-Commercial License.
 
 
 🔧 If you want to check the **default hyperparameters and hyperparameter search spaces** of all methods, please visit:  
@@ -280,7 +282,7 @@ for s in TALENT.list_methods(
 
 Both the CLI scripts and the Python API are backed by the same `MethodSpec` registry, so adding a new method requires only a single registry entry (see `TALENT/model/method_registry.py`).
 
-The registry is also the single source of truth for foundation-model training-row caps (`train_row_limit`): TabPFN 1k, TabPFN v2 / Real-TabPFN / Mitra 10k, TabPFN v2.5 50k, TabICL 500k, TabPFN v3 / TabICL v2 1M, TabDPT unlimited. The cap is applied automatically when fitting; setting `config['general']['sample_size']` overrides it for a single run.
+The registry is also the single source of truth for foundation-model training-row caps (`train_row_limit`): TabPFN 1k, TabPFN v2 / Real-TabPFN / Mitra 10k, TabPFN v2.5 50k, TabICL 500k, TabPFN v3 / TabICL v2 1M, TabDPT / TabFM no registry cap. The cap is applied automatically when fitting; setting `config['general']['sample_size']` overrides it for a single run.
 
 
 
@@ -425,6 +427,7 @@ We thank the following repos for providing helpful components/functions in our w
 - [LimiX](https://github.com/limix-ldm/LimiX)
 - [xRFM](https://github.com/dmbeaglehole/xRFM)
 - [TabDPT](https://github.com/layer6ai-labs/TabDPT-inference)
+- [TabFM](https://github.com/google-research/tabfm)
 
 ## 🤗 Contact
 


### PR DESCRIPTION
# Add TabFM and fix foundation-model integration bugs

## Summary

- Add `tabfm`, an optional Google Research TabFM v1.0.0 method wrapper using the upstream `tabfm[pytorch]` package.
- Register `tabfm` in the unified method registry and add matching default / opt-space configs.
- Document TabFM in the README, including the optional install command and the upstream non-commercial model-weight license caveat.
- Fix `TALENT/configs/opt_space/tabptm.json`, whose top-level key incorrectly pointed to `tabpfn`.
- Fix shared preprocessing edge cases:
  - unknown categorical values now map to the training-column mode as documented;
  - constant regression targets no longer divide by zero during label normalization.
- Fix Python API argument handling so `TALENT.run(..., args=...)` respects supplied `seed`, `seed_num`, `tune`, `n_trials`, and `tune_metric` fields unless explicitly overridden.
- Make TabPTM temporary tensors follow the active device instead of hardcoding CUDA.

## Notes

- `tabfm` is optional and not added as a hard dependency. Users should install it with:

  ```bash
  pip install -U "tabfm[pytorch]"
  ```

- TabFM v1.0.0 classification is limited to 10 classes by the upstream model. The wrapper raises a clear `ValueError` before loading the model if a dataset exceeds that limit.
- The wrapper uses the PyTorch backend because TALENT already centers on PyTorch and the upstream TabFM package exposes `tabfm_v1_0_0_pytorch`.
- The upstream TabFM source code is Apache 2.0, while the published model weights are under the TabFM Non-Commercial License.

## Validation

- `python -m compileall -q TALENT test`
- `git diff --check`
- Registry/config consistency check:
  - 56 registered methods;
  - no missing config files;
  - no mismatched config top-level keys.
- Focused preprocessing checks for categorical unknown replacement and constant regression target normalization.
- API behavior check confirming `args.tune=True` is now honored by `TALENT.run(..., args=...)`.

## Follow-Up

- Full runtime smoke tests for `tabfm` require installing `tabfm[pytorch]` and downloading the upstream Hugging Face weights.
- Consider adding a lightweight CI test that checks registry/config consistency for every registered method.
