### PR TITLE
Add Deep Tabular Representation Corrector (TRC)

### DIFF
--- a/TALENT/configs/default/trc.json
+++ b/TALENT/configs/default/trc.json
@@ -1,0 +1,40 @@
+{
+    "trc": {
+        "model": {
+            "embedding_num": 10,
+            "shift_estimator": true,
+            "space_mapping": true,
+            "loss_orth": true,
+            "reg_weight": 0.1,
+            "tau": 0.01,
+            "optimal_loss_fraction": 0.2,
+            "perturb_times": 3,
+            "mask_keep_min": 0.1,
+            "mask_keep_max": 0.3,
+            "backbone": {
+                "token_bias": true,
+                "n_layers": 3,
+                "d_token": 192,
+                "n_heads": 8,
+                "d_ffn_factor": 1.3333333333333333,
+                "attention_dropout": 0.2,
+                "ffn_dropout": 0.1,
+                "residual_dropout": 0.0,
+                "activation": "reglu",
+                "prenormalization": false,
+                "initialization": "kaiming",
+                "kv_compression": null,
+                "kv_compression_sharing": null
+            }
+        },
+        "training": {
+            "lr": 0.0001,
+            "weight_decay": 0.00001,
+            "backbone_lr": 0.0001,
+            "backbone_weight_decay": 0.00001,
+            "backbone_patience": 10,
+            "trc_patience": 10
+        },
+        "general": {}
+    }
+}

--- a/TALENT/configs/opt_space/trc.json
+++ b/TALENT/configs/opt_space/trc.json
@@ -1,0 +1,25 @@
+{
+    "trc": {
+        "model": {
+            "embedding_num": ["categorical", [5, 10, 15, 20, 25]],
+            "reg_weight": ["loguniform", 0.01, 0.25],
+            "tau": ["categorical", [0.005, 0.01, 0.04, 0.07, 0.1]],
+            "perturb_times": ["categorical", [1, 3, 5]],
+            "backbone": {
+                "n_layers": ["int", 1, 4],
+                "d_token": ["categorical", [32, 64, 128, 192]],
+                "attention_dropout": ["uniform", 0.0, 0.5],
+                "ffn_dropout": ["uniform", 0.0, 0.5],
+                "residual_dropout": ["uniform", 0.0, 0.2],
+                "d_ffn_factor": ["uniform", 0.6666666666666667, 2.6666666666666665]
+            }
+        },
+        "training": {
+            "lr": ["loguniform", 0.00001, 0.001],
+            "weight_decay": ["loguniform", 0.000001, 0.001],
+            "backbone_lr": ["loguniform", 0.00001, 0.001],
+            "backbone_weight_decay": ["loguniform", 0.000001, 0.001]
+        },
+        "general": {}
+    }
+}

--- a/TALENT/model/method_registry.py
+++ b/TALENT/model/method_registry.py
@@ -255,6 +255,10 @@ _METHODS_DEEP = [
           _DEEP, _GPU, _LOGITS, cat_policy=_ALL_CAT_POLICIES),
     _spec("ptarl", "TALENT.model.methods.ptarl", "PTARLMethod",
           _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
+    _spec("trc", "TALENT.model.methods.trc", "TRCMethod",
+          _DEEP, _GPU, _LOGITS, cat_policy=("indices",),
+          notes="Deep Tabular Representation Corrector with a frozen "
+                "FT-Transformer backbone and two-stage training."),
     _spec("bishop", "TALENT.model.methods.bishop", "BiSHopMethod",
           _DEEP, _GPU, _LOGITS, cat_policy=("indices",)),
     _spec("protogate", "TALENT.model.methods.protogate", "ProtoGateMethod",

--- a/TALENT/model/methods/trc.py
+++ b/TALENT/model/methods/trc.py
@@ -1,0 +1,418 @@
+"""TALENT integration for Deep Tabular Representation Corrector (TRC)."""
+
+from __future__ import annotations
+
+import copy
+import os
+import os.path as osp
+import time
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, Subset
+
+from TALENT.model.lib.data import Dataset
+from TALENT.model.lib.tuning_metric import select_objective
+from TALENT.model.methods.base import Method
+from TALENT.model.utils import Averager
+
+
+class TRCMethod(Method):
+    """Train an FT-Transformer backbone, freeze it, then fit TRC.
+
+    TRC is a post-hoc representation method rather than a conventional
+    end-to-end architecture.  Consequently ``fit`` implements the two stages
+    from Algorithm 1 instead of using :class:`Method`'s single training loop.
+    """
+
+    def __init__(self, args, is_regression):
+        super().__init__(args, is_regression)
+        assert args.cat_policy == "indices"
+
+    @staticmethod
+    def _model_defaults(config):
+        config = copy.deepcopy(config)
+        config.setdefault("embedding_num", 10)
+        config.setdefault("shift_estimator", True)
+        config.setdefault("space_mapping", True)
+        config.setdefault("loss_orth", True)
+        config.setdefault("reg_weight", 0.1)
+        config.setdefault("tau", 0.01)
+        config.setdefault("optimal_loss_fraction", 0.2)
+        config.setdefault("perturb_times", 3)
+        config.setdefault("mask_keep_min", 0.1)
+        config.setdefault("mask_keep_max", 0.3)
+        backbone_defaults = {
+            "token_bias": True,
+            "n_layers": 3,
+            "d_token": 192,
+            "n_heads": 8,
+            "d_ffn_factor": 4.0 / 3.0,
+            "attention_dropout": 0.2,
+            "ffn_dropout": 0.1,
+            "residual_dropout": 0.0,
+            "activation": "reglu",
+            "prenormalization": False,
+            "initialization": "kaiming",
+            "kv_compression": None,
+            "kv_compression_sharing": None,
+        }
+        backbone_config = config.setdefault("backbone", {})
+        for key, value in backbone_defaults.items():
+            backbone_config.setdefault(key, value)
+        return config
+
+    @staticmethod
+    def _training_defaults(config):
+        config = copy.deepcopy(config)
+        config.setdefault("lr", 1e-4)
+        config.setdefault("weight_decay", 1e-5)
+        config.setdefault("backbone_lr", 1e-4)
+        config.setdefault("backbone_weight_decay", 1e-5)
+        config.setdefault("backbone_patience", 10)
+        config.setdefault("trc_patience", 10)
+        return config
+
+    def construct_model(self, model_config=None):
+        from TALENT.model.models.ftt import Transformer
+        from TALENT.model.models.trc import TRC
+
+        if model_config is None:
+            model_config = self.args.config["model"]
+        model_config = self._model_defaults(model_config)
+        self.trc_config = model_config
+
+        backbone_config = model_config["backbone"]
+        backbone = Transformer(
+            d_numerical=self.d_in,
+            categories=self.categories,
+            d_out=self.d_out,
+            **backbone_config,
+        )
+        self.model = TRC(
+            backbone=backbone,
+            hidden_dim=backbone_config["d_token"],
+            d_out=self.d_out,
+            embedding_num=model_config["embedding_num"],
+            shift_estimator=model_config["shift_estimator"],
+            space_mapping=model_config["space_mapping"],
+            loss_orth=model_config["loss_orth"],
+        ).to(self.args.device)
+        if self.args.use_float:
+            self.model.float()
+        else:
+            self.model.double()
+
+    def _split_features(
+        self, X
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if self.N is not None and self.C is not None:
+            return X[0], X[1]
+        if self.C is not None:
+            return None, X
+        return X, None
+
+    def _run_backbone_epoch(self, loader, optimizer=None):
+        backbone = self.model.backbone
+        backbone.train(optimizer is not None)
+        total = Averager()
+        context = torch.enable_grad() if optimizer is not None else torch.no_grad()
+        with context:
+            for X, y in loader:
+                X_num, X_cat = self._split_features(X)
+                loss = self.criterion(backbone(X_num, X_cat), y)
+                if optimizer is not None:
+                    optimizer.zero_grad()
+                    loss.backward()
+                    optimizer.step()
+                total.add(loss.item())
+        return total.item()
+
+    def _fit_backbone(self, training_config):
+        backbone = self.model.backbone
+        for parameter in backbone.parameters():
+            parameter.requires_grad_(True)
+        optimizer = torch.optim.AdamW(
+            backbone.parameters(),
+            lr=training_config["backbone_lr"],
+            weight_decay=training_config["backbone_weight_decay"],
+        )
+
+        best_loss = float("inf")
+        best_state = None
+        stale_epochs = 0
+        patience = int(training_config["backbone_patience"])
+        for epoch in range(max(1, int(self.args.max_epoch))):
+            train_loss = self._run_backbone_epoch(self.train_loader, optimizer)
+            val_loss = self._run_backbone_epoch(self.val_loader)
+            print(
+                f"Backbone epoch {epoch}: train loss={train_loss:.4f}, "
+                f"val loss={val_loss:.4f}"
+            )
+            if val_loss < best_loss:
+                best_loss = val_loss
+                best_state = copy.deepcopy(backbone.state_dict())
+                stale_epochs = 0
+            else:
+                stale_epochs += 1
+                if stale_epochs >= patience:
+                    break
+
+        if best_state is None:
+            raise RuntimeError("The TRC backbone did not complete an epoch")
+        backbone.load_state_dict(best_state)
+        self.model.freeze_backbone()
+
+    def _per_sample_losses(self):
+        losses = []
+        backbone = self.model.backbone
+        backbone.eval()
+        with torch.no_grad():
+            for X, y in self.val_loader:
+                X_num, X_cat = self._split_features(X)
+                prediction = backbone(X_num, X_cat)
+                if self.is_regression:
+                    batch_losses = (prediction.reshape(-1) - y.reshape(-1)).square()
+                else:
+                    batch_losses = F.cross_entropy(prediction, y, reduction="none")
+                losses.append(batch_losses.detach())
+        if not losses:
+            raise ValueError("TRC requires a non-empty validation split")
+        return torch.cat(losses)
+
+    def _gradient_norm(self, dataset_index: int) -> float:
+        X, y = self.val_loader.dataset[dataset_index]
+        X_num, X_cat = self._split_features(X)
+        X_num = None if X_num is None else X_num.unsqueeze(0)
+        X_cat = None if X_cat is None else X_cat.unsqueeze(0)
+        y = y.unsqueeze(0)
+
+        backbone = self.model.backbone
+        parameters = [parameter for parameter in backbone.parameters()]
+        prediction = backbone(X_num, X_cat)
+        loss = self.criterion(prediction, y)
+        gradients = torch.autograd.grad(
+            loss,
+            parameters,
+            allow_unused=True,
+            retain_graph=False,
+            create_graph=False,
+        )
+        nonempty = [
+            gradient.detach().abs().reshape(-1)
+            for gradient in gradients
+            if gradient is not None
+        ]
+        if not nonempty:
+            return float("inf")
+        return torch.cat(nonempty).mean().item()
+
+    def _find_optimal_subset(self):
+        """Search validation samples with low loss, then low gradient norm."""
+        losses = self._per_sample_losses()
+        n_validation = len(losses)
+        fraction = float(self.trc_config["optimal_loss_fraction"])
+        if not 0.0 < fraction <= 1.0:
+            raise ValueError("optimal_loss_fraction must be in (0, 1]")
+        tau = float(self.trc_config["tau"])
+        if not 0.0 < tau <= 1.0:
+            raise ValueError("tau must be in (0, 1]")
+
+        candidate_count = max(1, int(n_validation * fraction))
+        candidates = torch.argsort(losses)[:candidate_count].cpu().tolist()
+
+        backbone = self.model.backbone
+        for parameter in backbone.parameters():
+            parameter.requires_grad_(True)
+        backbone.eval()
+        gradient_norms = [self._gradient_norm(index) for index in candidates]
+        self.model.freeze_backbone()
+
+        selected_count = min(candidate_count, max(1, int(n_validation * tau)))
+        ordering = np.argsort(np.asarray(gradient_norms))[:selected_count]
+        selected_indices = [candidates[index] for index in ordering]
+        subset = Subset(self.val_loader.dataset, selected_indices)
+        return DataLoader(
+            subset,
+            batch_size=min(self.args.batch_size, len(subset)),
+            shuffle=True,
+            num_workers=0,
+        )
+
+    @staticmethod
+    def _perturb_tensor(values, distribution, keep_probability):
+        if values is None:
+            return None
+        batch_size, n_features = values.shape
+        rows = torch.randint(
+            distribution.shape[0],
+            (batch_size, n_features),
+            device=values.device,
+        )
+        columns = torch.arange(n_features, device=values.device).expand(batch_size, -1)
+        noise = distribution[rows, columns]
+        mask = (
+            torch.rand(batch_size, n_features, device=values.device)
+            < keep_probability
+        )
+        return torch.where(mask, values, noise)
+
+    def _perturb(self, X_num, X_cat):
+        keep_min = float(self.trc_config["mask_keep_min"])
+        keep_max = float(self.trc_config["mask_keep_max"])
+        if not 0.0 <= keep_min <= keep_max <= 1.0:
+            raise ValueError(
+                "mask keep probabilities must satisfy 0 <= min <= max <= 1"
+            )
+        batch_size = X_num.shape[0] if X_num is not None else X_cat.shape[0]
+        keep_probability = torch.empty(
+            batch_size, 1, device=self.args.device
+        ).uniform_(keep_min, keep_max)
+        train_dataset = self.train_loader.dataset
+        return (
+            self._perturb_tensor(X_num, train_dataset.X_num, keep_probability),
+            self._perturb_tensor(X_cat, train_dataset.X_cat, keep_probability),
+        )
+
+    def _train_shift_estimator(self, optimal_loader, optimizer):
+        if self.model.shift_estimator is None:
+            return 0.0
+        self.model.train()
+        total = Averager()
+        perturb_times = int(self.trc_config["perturb_times"])
+        if perturb_times <= 0:
+            raise ValueError("perturb_times must be positive")
+
+        for X, _ in optimal_loader:
+            X_num, X_cat = self._split_features(X)
+            clean = self.model.encode_backbone(X_num, X_cat)
+            loss = F.mse_loss(self.model.shift_estimator(clean), torch.zeros_like(clean))
+            for _ in range(perturb_times):
+                corrupted_num, corrupted_cat = self._perturb(X_num, X_cat)
+                corrupted = self.model.encode_backbone(corrupted_num, corrupted_cat)
+                target_shift = corrupted - clean
+                loss = loss + F.mse_loss(
+                    self.model.shift_estimator(corrupted), target_shift
+                )
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            total.add(loss.item())
+        return total.item()
+
+    def _run_trc_epoch(self, loader, optimizer=None):
+        self.model.train(optimizer is not None)
+        total = Averager()
+        context = torch.enable_grad() if optimizer is not None else torch.no_grad()
+        with context:
+            for X, y in loader:
+                X_num, X_cat = self._split_features(X)
+                loss = self.criterion(self.model(X_num, X_cat), y)
+                if self.model.use_orthogonal_loss:
+                    loss = (
+                        loss
+                        + float(self.trc_config["reg_weight"])
+                        * self.model.orthogonality_loss()
+                    )
+                if optimizer is not None:
+                    optimizer.zero_grad()
+                    loss.backward()
+                    optimizer.step()
+                total.add(loss.item())
+        return total.item()
+
+    def _validation_metrics(self):
+        logits, labels = [], []
+        self.model.eval()
+        with torch.no_grad():
+            for X, y in self.val_loader:
+                X_num, X_cat = self._split_features(X)
+                logits.append(self.model(X_num, X_cat))
+                labels.append(y)
+        logits = torch.cat(logits)
+        labels = torch.cat(labels)
+        val_loss = self.criterion(logits, labels).item()
+        metrics, names = self.metric(logits, labels, self.y_info)
+        score, _ = select_objective(metrics, names, self.args, self.is_regression)
+        return val_loss, score
+
+    def _fit_trc(self, training_config):
+        optimal_loader = (
+            self._find_optimal_subset()
+            if self.model.shift_estimator is not None
+            else None
+        )
+        parameters = list(self.model.correction_parameters())
+        self.optimizer = torch.optim.AdamW(
+            parameters,
+            lr=training_config["lr"],
+            weight_decay=training_config["weight_decay"],
+        )
+
+        best_loss = float("inf")
+        best_state = None
+        stale_epochs = 0
+        patience = int(training_config["trc_patience"])
+        for epoch in range(max(1, int(self.args.max_epoch))):
+            shift_loss = (
+                self._train_shift_estimator(optimal_loader, self.optimizer)
+                if optimal_loader is not None
+                else 0.0
+            )
+            train_loss = self._run_trc_epoch(self.train_loader, self.optimizer)
+            val_loss, score = self._validation_metrics()
+            self.trlog["train_loss"].append(train_loss)
+            print(
+                f"TRC epoch {epoch}: shift loss={shift_loss:.4f}, "
+                f"train loss={train_loss:.4f}, val loss={val_loss:.4f}"
+            )
+
+            if val_loss < best_loss:
+                best_loss = val_loss
+                best_state = copy.deepcopy(self.model.state_dict())
+                self.trlog["best_epoch"] = epoch
+                self.trlog["best_res"] = score
+                torch.save(
+                    {"params": best_state},
+                    osp.join(self.args.save_path, f"best-val-{self.args.seed}.pth"),
+                )
+                stale_epochs = 0
+            else:
+                stale_epochs += 1
+                if stale_epochs >= patience:
+                    break
+
+        if best_state is None:
+            raise RuntimeError("TRC did not complete an epoch")
+        self.model.load_state_dict(best_state)
+
+    def fit(self, data, info, train=True, config=None):
+        start = time.time()
+        N, C, y = data
+        self.D = Dataset(N, C, y, info)
+        self.N, self.C, self.y = self.D.N, self.D.C, self.D.y
+        self.is_binclass = self.D.is_binclass
+        self.is_multiclass = self.D.is_multiclass
+        self.is_regression = self.D.is_regression
+        self.n_num_features = self.D.n_num_features
+        self.n_cat_features = self.D.n_cat_features
+        if config is not None:
+            self.reset_stats_withconfig(config)
+
+        self.data_format(is_train=True)
+        self.construct_model()
+        if not train:
+            return
+
+        os.makedirs(self.args.save_path, exist_ok=True)
+        training_config = self._training_defaults(self.args.config["training"])
+        self._fit_backbone(training_config)
+        self._fit_trc(training_config)
+        torch.save(
+            {"params": self.model.state_dict()},
+            osp.join(self.args.save_path, f"epoch-last-{self.args.seed}.pth"),
+        )
+        torch.save(self.trlog, osp.join(self.args.save_path, "trlog"))
+        self.fit_time = time.time() - start

--- a/TALENT/model/models/ftt.py
+++ b/TALENT/model/models/ftt.py
@@ -289,9 +289,13 @@ class Transformer(nn.Module):
             x = layer[f'norm{norm_idx}'](x)
         return x
 
-    def forward(self, x_num: Tensor, x_cat: ty.Optional[Tensor]) -> Tensor:
-        
+    def encode(self, x_num: Tensor, x_cat: ty.Optional[Tensor]) -> Tensor:
+        """Return the representation immediately before the prediction head.
 
+        Keeping representation extraction separate from ``forward`` lets
+        post-hoc methods such as TRC reuse a trained FT-Transformer without
+        changing its prediction behaviour.
+        """
         x = self.tokenizer(x_num, x_cat)
 
         for layer_idx, layer in enumerate(self.layers):
@@ -322,6 +326,10 @@ class Transformer(nn.Module):
         if self.last_normalization is not None:
             x = self.last_normalization(x)
         x = self.last_activation(x)
+        return x
+
+    def forward(self, x_num: Tensor, x_cat: ty.Optional[Tensor]) -> Tensor:
+        x = self.encode(x_num, x_cat)
         x = self.head(x)
         x = x.squeeze(-1)
         return x

--- a/TALENT/model/models/trc.py
+++ b/TALENT/model/models/trc.py
@@ -1,0 +1,136 @@
+"""Tabular Representation Corrector (TRC).
+
+The implementation follows Algorithm 1 of "Deep Tabular Representation
+Corrector".  TRC is deliberately kept independent of the TALENT training
+loop: the method wrapper owns the two-stage optimisation, while this module
+contains the reusable frozen-backbone correction network.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class TRC(nn.Module):
+    """Correct representations produced by an already-trained backbone.
+
+    The backbone must expose ``encode(x_num, x_cat)`` and return a 2-D tensor
+    of shape ``(batch, hidden_dim)``.  Its parameters are frozen permanently;
+    only the shift estimator, coordinate estimator, embedding vectors and the
+    re-initialised prediction head are optimised during the TRC stage.
+    """
+
+    def __init__(
+        self,
+        *,
+        backbone: nn.Module,
+        hidden_dim: int,
+        d_out: int,
+        embedding_num: int = 10,
+        shift_estimator: bool = True,
+        space_mapping: bool = True,
+        loss_orth: bool = True,
+    ) -> None:
+        super().__init__()
+        if hidden_dim <= 0:
+            raise ValueError("hidden_dim must be positive")
+        if embedding_num <= 0:
+            raise ValueError("embedding_num must be positive")
+        self.backbone = backbone
+        self.hidden_dim = hidden_dim
+        self.d_out = d_out
+        self.embedding_num = embedding_num
+        self.use_shift_estimator = shift_estimator
+        self.use_space_mapping = space_mapping
+        self.use_orthogonal_loss = loss_orth and space_mapping
+
+        if self.use_shift_estimator:
+            self.shift_estimator = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.ReLU(),
+                nn.Linear(hidden_dim, hidden_dim),
+            )
+        else:
+            self.shift_estimator = None
+
+        if self.use_space_mapping:
+            self.coordinate_estimator = nn.Linear(hidden_dim, embedding_num)
+            self.embedding_vectors = nn.Parameter(
+                torch.empty(embedding_num, hidden_dim)
+            )
+            nn.init.normal_(self.embedding_vectors)
+        else:
+            self.coordinate_estimator = None
+            self.register_parameter("embedding_vectors", None)
+
+        self.head = nn.Linear(hidden_dim, d_out)
+        self.freeze_backbone()
+
+    def freeze_backbone(self) -> None:
+        for parameter in self.backbone.parameters():
+            parameter.requires_grad_(False)
+        self.backbone.eval()
+
+    def train(self, mode: bool = True):
+        """Keep dropout/normalisation in the frozen backbone deterministic."""
+        super().train(mode)
+        self.backbone.eval()
+        return self
+
+    def encode_backbone(self, x_num, x_cat) -> torch.Tensor:
+        with torch.no_grad():
+            representation = self.backbone.encode(x_num, x_cat)
+        if representation.ndim != 2 or representation.shape[-1] != self.hidden_dim:
+            raise RuntimeError(
+                "backbone.encode() must return (batch, hidden_dim); got "
+                f"{tuple(representation.shape)}"
+            )
+        return representation.detach()
+
+    def reestimate(self, representation: torch.Tensor) -> torch.Tensor:
+        if self.shift_estimator is None:
+            return representation
+        return representation - self.shift_estimator(representation)
+
+    def map_space(self, representation: torch.Tensor) -> torch.Tensor:
+        if self.coordinate_estimator is None:
+            return representation
+        coordinates = F.softmax(self.coordinate_estimator(representation), dim=-1)
+        return coordinates @ self.embedding_vectors
+
+    def forward_from_representation(self, representation: torch.Tensor) -> torch.Tensor:
+        corrected = self.reestimate(representation)
+        corrected = self.map_space(corrected)
+        output = self.head(corrected)
+        return output.squeeze(-1) if self.d_out == 1 else output
+
+    def forward(self, x_num, x_cat=None) -> torch.Tensor:
+        representation = self.encode_backbone(x_num, x_cat)
+        return self.forward_from_representation(representation)
+
+    def correction_parameters(self) -> Iterable[nn.Parameter]:
+        """Yield all and only parameters trained in the TRC stage."""
+        if self.shift_estimator is not None:
+            yield from self.shift_estimator.parameters()
+        if self.coordinate_estimator is not None:
+            yield from self.coordinate_estimator.parameters()
+            yield self.embedding_vectors
+        yield from self.head.parameters()
+
+    def orthogonality_loss(self) -> torch.Tensor:
+        """Diversify light-space vectors as in the authors' implementation."""
+        if self.embedding_vectors is None:
+            return self.head.weight.new_zeros(())
+        normalized = F.normalize(self.embedding_vectors, p=2, dim=1)
+        similarity = (normalized @ normalized.T).abs().clamp(0.0, 1.0)
+        l1 = similarity.sum()
+        l2_squared = similarity.square().sum().clamp_min(
+            torch.finfo(similarity.dtype).eps
+        )
+        sparse_term = l1 / l2_squared
+        constraint_term = (l1 - self.embedding_num).abs()
+        return sparse_term + 0.5 * constraint_term

--- a/docs/api/lib.rst
+++ b/docs/api/lib.rst
@@ -46,6 +46,7 @@ Available Components
 - :doc:`Periodic Tabular DL <lib/periodic_tab_dl>`: Periodic embeddings for tabular data
 - :doc:`TROMPT <lib/trompt>`: Tabular prompting mechanisms
 - :doc:`PTARL <lib/ptarl>`: Policy gradient methods for tabular RL
+- :doc:`TRC <lib/trc>`: Post-hoc representation re-estimation and light-space mapping
 - :doc:`AmFormer <lib/amformer>`: Attention mechanisms for transformers
 - :doc:`TabPTM <lib/tabptm>`: Pre-trained models for tabular data
 - :doc:`DNNR <lib/dnnr>`: Deep nearest neighbor regression
@@ -72,6 +73,7 @@ Available Components
    lib/periodic_tab_dl
    lib/trompt
    lib/ptarl
+   lib/trc
    lib/amformer
    lib/tabptm
    lib/dnnr

--- a/docs/api/lib/trc.rst
+++ b/docs/api/lib/trc.rst
@@ -1,0 +1,41 @@
+Deep Tabular Representation Corrector (TRC)
+===========================================
+
+TRC is a post-hoc representation method. TALENT first trains an
+FT-Transformer backbone, freezes all of its parameters, searches the
+validation split for approximated optimal representations, and then learns:
+
+* a two-layer shift estimator for representation re-estimation;
+* a coordinate estimator and compact set of embedding vectors for light-space
+  mapping;
+* a re-initialized prediction head.
+
+The implementation follows Algorithm 1 from `Deep Tabular Representation
+Corrector <https://arxiv.org/abs/2603.16569>`_ and supports regression, binary
+classification, and multiclass classification.
+
+Usage
+-----
+
+.. code-block:: bash
+
+   python train_model_deep.py --model_type trc --cat_policy indices
+
+The main parameters are defined in ``TALENT/configs/default/trc.json``.
+``tau`` controls the ratio of approximated optimal validation representations,
+``perturb_times`` controls the number of simulated shifts, ``embedding_num``
+sets the number of light-space vectors, and ``reg_weight`` weights the
+orthogonality objective.
+
+API
+---
+
+.. automodule:: TALENT.model.models.trc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: TALENT.model.methods.trc
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Welcome to **TALENT**, a benchmark with a comprehensive machine learning toolbox
 
 ## 📰 What's New
 
+- [2026-08]🌟 Add **[TRC](https://arxiv.org/abs/2603.16569)** (TPAMI 2026), a post-hoc representation corrector that trains and freezes an FT-Transformer backbone before learning representation re-estimation and light-space mapping.
 - [2026-07]🌟 Add **[TabFM](https://github.com/google-research/tabfm)** (Google Research, zero-shot tabular foundation model) as an optional method via `pip install -U "tabfm[pytorch]"`.
 - [2026-06]🌟 Add **[TabPFN v2.5](https://arxiv.org/abs/2511.08667)** (PriorLabs, Nov 2025) and **[TabDPT](https://github.com/layer6ai-labs/TabDPT-inference)** (Layer 6 AI, ICL + retrieval). TALENT now ships the full TabPFN family (v1, v2, v2.5, v3) plus TabDPT alongside the other tabular foundation models.
 - [2026-06]🌟 Evaluation improvements: **calibration metrics** (Brier, ECE) are now reported by default for every classifier, **decision thresholds** are tuned on the validation set for binary classification (used for Accuracy/F1/Precision/Recall; threshold-independent metrics like AUC/LogLoss/Brier/ECE are unaffected), and `RunResult` exposes a uniform `predict_proba`/`predict_labels` interface regardless of whether the underlying method natively returns logits or probabilities. Bundled checkpoints are now resolved via `importlib.resources` so methods work from any working directory.
@@ -161,6 +162,7 @@ TALENT integrates an extensive array of 30+ deep learning architectures for tabu
 43. **[TabPFN v2.5](https://arxiv.org/abs/2511.08667)**: TabPFN v2.5 (PriorLabs, Nov 2025), the intermediate release between v2 and v3. Scales in-context learning to ~50k rows × 2k features. Requires `pip install -U 'tabpfn>=8.0.0'`.
 44. **[TabDPT](https://github.com/layer6ai-labs/TabDPT-inference)**: A tabular foundation model from Layer 6 AI that combines in-context learning with retrieval and self-supervised pre-training on real data, removing fixed context-size limits. Requires `pip install -U tabdpt`.
 45. **[TabFM](https://github.com/google-research/tabfm)**: Google's zero-shot tabular foundation model for classification and regression, using in-context learning over training rows as context. Requires `pip install -U "tabfm[pytorch]"`; the upstream model weights use the TabFM Non-Commercial License.
+46. **[TRC](https://arxiv.org/abs/2603.16569)**: A post-hoc Tabular Representation Corrector that freezes a trained backbone, learns to remove representation shift, and maps corrected representations into a compact light-embedding space.
 
 
 🔧 If you want to check the **default hyperparameters and hyperparameter search spaces** of all methods, please visit:  
@@ -219,6 +221,19 @@ if __name__ == '__main__':
 ```bash
 python train_model_deep.py --model_type MODEL_NAME
 ```
+
+For TRC, use integer-encoded categorical features as required by its
+FT-Transformer backbone:
+
+```bash
+python train_model_deep.py --model_type trc --cat_policy indices
+```
+
+TRC first trains the backbone for at most `--max_epoch` epochs, freezes it,
+and then trains the representation corrector for at most the same number of
+epochs. Ablations and paper hyperparameters are available in
+`TALENT/configs/default/trc.json`; set `shift_estimator`, `space_mapping`, or
+`loss_orth` to `false` to disable the corresponding component.
 
 ### 🐍 Python API (library mode)
 

--- a/test/test_trc.py
+++ b/test/test_trc.py
@@ -1,0 +1,151 @@
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from TALENT.api import build_args
+from TALENT.model.method_registry import get_method_spec
+from TALENT.model.models.trc import TRC
+
+
+class _TinyBackbone(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.encoder = nn.Linear(3, 6)
+        self.head = nn.Linear(6, 2)
+
+    def encode(self, x_num, x_cat=None):
+        return torch.relu(self.encoder(x_num))
+
+    def forward(self, x_num, x_cat=None):
+        return self.head(self.encode(x_num, x_cat))
+
+
+class TRCModelTest(unittest.TestCase):
+    def test_forward_freezes_backbone_and_preserves_shape(self):
+        model = TRC(
+            backbone=_TinyBackbone(),
+            hidden_dim=6,
+            d_out=2,
+            embedding_num=3,
+        )
+        model.train()
+        output = model(torch.randn(5, 3))
+
+        self.assertEqual(output.shape, (5, 2))
+        self.assertFalse(model.backbone.training)
+        self.assertTrue(all(not p.requires_grad for p in model.backbone.parameters()))
+        self.assertGreaterEqual(model.orthogonality_loss().item(), 0.0)
+
+    def test_ablation_without_space_mapping(self):
+        model = TRC(
+            backbone=_TinyBackbone(),
+            hidden_dim=6,
+            d_out=1,
+            shift_estimator=False,
+            space_mapping=False,
+            loss_orth=False,
+        )
+        self.assertEqual(model(torch.randn(4, 3)).shape, (4,))
+        self.assertEqual(model.orthogonality_loss().item(), 0.0)
+
+
+class TRCIntegrationTest(unittest.TestCase):
+    def test_registry_and_packaged_config(self):
+        spec = get_method_spec("trc")
+        self.assertEqual(spec.cat_policy, ("indices",))
+        config_path = Path(__file__).parents[1] / "TALENT" / "configs" / "default" / "trc.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        self.assertIn("trc", config)
+        self.assertEqual(config["trc"]["model"]["embedding_num"], 10)
+
+    def test_tiny_cpu_fit_and_predict(self):
+        rng = np.random.default_rng(7)
+        sizes = {"train": 12, "val": 6, "test": 6}
+        numerical = {
+            split: rng.normal(size=(size, 2)).astype("float32")
+            for split, size in sizes.items()
+        }
+        categorical = {
+            split: np.asarray(
+                [["a" if index % 2 else "b"] for index in range(size)],
+                dtype=object,
+            )
+            for split, size in sizes.items()
+        }
+        labels = {
+            split: np.asarray([index % 2 for index in range(size)], dtype="int64")
+            for split, size in sizes.items()
+        }
+        train_val = (
+            {key: numerical[key] for key in ("train", "val")},
+            {key: categorical[key] for key in ("train", "val")},
+            {key: labels[key] for key in ("train", "val")},
+        )
+        test = (
+            {"test": numerical["test"]},
+            {"test": categorical["test"]},
+            {"test": labels["test"]},
+        )
+        info = {"task_type": "binclass", "n_num_features": 2, "n_cat_features": 1}
+
+        config = {
+            "model": {
+                "embedding_num": 3,
+                "tau": 0.2,
+                "optimal_loss_fraction": 0.5,
+                "perturb_times": 1,
+                "backbone": {
+                    "token_bias": True,
+                    "n_layers": 1,
+                    "d_token": 8,
+                    "n_heads": 2,
+                    "d_ffn_factor": 1.0,
+                    "attention_dropout": 0.0,
+                    "ffn_dropout": 0.0,
+                    "residual_dropout": 0.0,
+                    "activation": "reglu",
+                    "prenormalization": False,
+                    "initialization": "kaiming",
+                    "kv_compression": None,
+                    "kv_compression_sharing": None,
+                },
+            },
+            "training": {
+                "lr": 1e-3,
+                "weight_decay": 0.0,
+                "backbone_lr": 1e-3,
+                "backbone_weight_decay": 0.0,
+                "backbone_patience": 1,
+                "trc_patience": 1,
+            },
+            "general": {},
+        }
+        with tempfile.TemporaryDirectory() as save_path:
+            args = build_args(
+                "trc",
+                save_path=save_path,
+                config=copy.deepcopy(config),
+                max_epoch=1,
+                batch_size=4,
+                normalization="none",
+                num_policy="none",
+                use_float=True,
+            )
+            method = get_method_spec("trc").get_class()(args, is_regression=False)
+            method.fit(train_val, info)
+            loss, metrics, names, predictions = method.predict(test, info, "best-val")
+
+        self.assertTrue(np.isfinite(loss))
+        self.assertEqual(predictions.shape, (sizes["test"], 2))
+        self.assertIn("Accuracy", names)
+        self.assertTrue(np.isfinite(metrics[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- integrate Deep Tabular Representation Corrector (TRC) as a registered TALENT deep method
- train and freeze an FT-Transformer backbone before alternating representation re-estimation and light-space mapping
- add the shift estimator, coordinate estimator, learnable embedding vectors, orthogonality regularization, paper defaults, HPO space, and ablation switches
- expose FT-Transformer representations through a backward-compatible `encode()` method
- document CLI usage and the new model API

The implementation follows [Deep Tabular Representation Corrector](https://arxiv.org/abs/2603.16569) and the authors' [reference implementation](https://github.com/HangtingYe/TRC), while removing hard-coded CUDA assumptions and supporting TALENT's numerical/categorical data pipeline.

## Testing

- `python -m unittest test.test_trc -v`
- 4 tests passed on CPU
- covers backbone freezing, forward/output shapes, component ablation, registry/config loading, and an end-to-end mixed-feature classification smoke test including checkpoint save/load and prediction
- `git diff --check`